### PR TITLE
Prep release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,8 @@
 name: Deploy to GitHub pages
 
 on:
-  push:
-    branches:
-      - prep-release
+  release:
+    types: [published]
 
 permissions:
   contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,9 @@
 name: Deploy to GitHub pages
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - prep-release
 
 permissions:
   contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,13 +30,14 @@ jobs:
 
       - name: build
         run: pnpm build
+        working-directory: ./apps/class-solid
         env:
           BASE_PATH: "/class-web"
 
       - name: upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ".output/public"
+          path: "./apps/class-solid/.output/public"
 
   deploy:
     name: Deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Deploy to GitHub pages
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20.12.0"
+          cache: "pnpm"
+
+      - name: install
+        run: pnpm install --frozen-lockfile
+
+      - name: build
+        run: pnpm build
+        env:
+          BASE_PATH: "/class-web"
+
+      - name: upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ".output/public"
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,33 +1,74 @@
-# `Turborepo` Vite starter
+# CLASS-web
 
-This is an official starter Turborepo.
+This is an implementation of CLASS that runs entirely in the browser.
 
-## Using this example
+The CLASS web application is available at https://classmodel.github.io/class-web.
 
-Run the following command:
+For more information on CLASS, see https://classmodel.github.io/.
+
+## Developers
+
+This repository is a so-called monorepo, where multiple packages and application
+can easily be developed in tandem.
+
+We used [TurboRepo](https://turbo.build/repo) for the initial setup, which uses
+[pnpm workspaces](https://pnpm.io/workspaces) under the hood. As such, it is
+possible to do advanced tricks with Turbo, such as "lint/test/build all
+apps/packages at once with `turbo build`", and share tooling configurations
+across packages/apps, but since this repo is small, we will not rely too much on
+these features.
+
+Currently the repo is home to the following:
+
+- packages/
+  - class: reimplementation of CLASS in typescript
+  - config-eslint: shared configuration for eslint
+  - config-typescript: shared configuration for typescript
+- apps/
+  - class-solid: web application with a graphical user interface for CLASS
+
+## Local build
+
+To run a local development version:
 
 ```sh
-npx create-turbo@latest -e with-vite
+git clone git@github.com:classmodel/class-web.git
+cd class-web/apps/class-solid
+pnpm install
+pnpm run dev
 ```
 
-## What's inside?
+## Tech stack
 
-This Turborepo includes the following packages and apps:
+The CLASS package is written in typescript. It uses [zod](https://zod.dev/) for
+the configuration and runtime validation. Zod can be converted to/from
+[JSONSchema](https://json-schema.org/), which is ideal for sharing the
+configuration between web-app, library code, and perhaps other implementations
+of CLASS as well.
 
-### Apps and Packages
+The web application is build with [solid.js](https://docs.solidjs.com/). Solid
+has a relatively simple model for building reactive web applications. With its
+metaframework [SolidStart](https://docs.solidjs.com/solid-start) it is quite
+easy to pre-render the web application as static pages that can be hosted on
+github pages.
 
-- `docs`: a vanilla [vite](https://vitejs.dev) ts app
-- `web`: another vanilla [vite](https://vitejs.dev) ts app
-- `@repo/ui`: a stub component & utility library shared by both `web` and `docs` applications
-- `@repo/eslint-config`: shared `eslint` configurations
-- `@repo/typescript-config`: `tsconfig.json`s used throughout the monorepo
+We've chosen [SolidUI](https://www.solid-ui.com/) as the basis for the UI. Build
+after [ShadCN](), SolidUI provides good-looking, accessible components (powered
+by [Kobalte](https://kobalte.dev/docs/core/overview/introduction) and
+[tailwind](https://tailwindcss.com/)) that can be copy-pasted into the web
+application and tweaked further as seen fit. It can also do charts, using
+[chart.js](https://www.chartjs.org/), though we might deviate from that later.
 
-Each package and app is 100% [TypeScript](https://www.typescriptlang.org/).
+**Further plans/ideas**
 
-### Utilities
-
-This Turborepo has some additional tools already setup for you:
-
-- [TypeScript](https://www.typescriptlang.org/) for static type checking
-- [ESLint](https://eslint.org/) for code linting
-- [Prettier](https://prettier.io) for code formatting
+- Use [biome](https://biomejs.dev/) for linting/formatting
+- Use [modular forms](https://modularforms.dev/) for form state management/validation
+- Use [auto](https://intuit.github.io/auto/index) for managing versions/releases
+- Use [d3.js](https://d3js.org/) for more low-level charting
+- Use [web workers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) to run CLASS off the main thread
+- Use [AssemblyScript](https://www.assemblyscript.org/) or
+  [rust](https://www.rust-lang.org/what/wasm) for a faster implementation of
+  CLASS running on web assembly.
+- Test with node test runner rather than jest (for the package) and/or use
+  [playwright](https://playwright.dev/) and/or
+  [storybook](https://storybook.js.org/) (for the web app)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CLASS-web
 
-This is an implementation of CLASS that runs entirely in the browser.
+This is an implementation of  the **C**hemistry **L**and-surface **A**tmosphere **S**oil **S**lab (CLASS) model that runs entirely in the browser.
 
 The CLASS web application is available at https://classmodel.github.io/class-web.
 
@@ -33,9 +33,9 @@ To run a local development version:
 
 ```sh
 git clone git@github.com:classmodel/class-web.git
-cd class-web/apps/class-solid
+cd class-web
 pnpm install
-pnpm run dev
+pnpm dev
 ```
 
 ## Tech stack
@@ -47,7 +47,7 @@ configuration between web-app, library code, and perhaps other implementations
 of CLASS as well.
 
 The web application is build with [solid.js](https://docs.solidjs.com/). Solid
-has a relatively simple model for building reactive web applications. With its
+is a relatively simple framework for building reactive web applications. With its
 metaframework [SolidStart](https://docs.solidjs.com/solid-start) it is quite
 easy to pre-render the web application as static pages that can be hosted on
 github pages.

--- a/apps/class-solid/app.config.ts
+++ b/apps/class-solid/app.config.ts
@@ -2,9 +2,11 @@ import { defineConfig } from "@solidjs/start/config";
 
 export default defineConfig({
   server: {
+    baseURL: process.env.BASE_PATH,
     static: true,
     prerender: {
-      routes: [],
+      failOnError: true,
+      routes: ["/"],
       crawlLinks: true,
     },
   },

--- a/apps/class-solid/package.json
+++ b/apps/class-solid/package.json
@@ -1,5 +1,7 @@
 {
   "name": "class-solid",
+  "private": true,
+  "version": "0.0.1",
   "type": "module",
   "scripts": {
     "dev": "vinxi dev",

--- a/apps/class-solid/src/app.tsx
+++ b/apps/class-solid/src/app.tsx
@@ -7,7 +7,8 @@ import "./app.css";
 export default function App() {
   return (
     <Router
-      root={props => (
+      base={import.meta.env.SERVER_BASE_URL}
+      root={(props) => (
         <>
           <Nav />
           <Suspense>{props.children}</Suspense>

--- a/apps/class-solid/src/routes/about.tsx
+++ b/apps/class-solid/src/routes/about.tsx
@@ -1,17 +1,14 @@
 import { A } from "@solidjs/router";
-import Counter from "~/components/Counter";
 
 export default function About() {
   return (
     <main class="text-center mx-auto text-gray-700 p-4">
-      <h1 class="max-6-xs text-6xl text-sky-700 font-thin uppercase my-16">About Page</h1>
-      <Counter />
+      <h1 class="max-6-xs text-6xl text-sky-700 font-thin uppercase my-16">
+        About Page
+      </h1>
       <p class="mt-8">
-        Visit{" "}
-        <a href="https://solidjs.com" target="_blank" class="text-sky-600 hover:underline">
-          solidjs.com
-        </a>{" "}
-        to learn how to build Solid apps.
+        Here, we're developing a new version of CLASS that can run in the
+        browser!
       </p>
       <p class="my-4">
         <A href="/" class="text-sky-600 hover:underline">

--- a/apps/class-solid/src/routes/index.tsx
+++ b/apps/class-solid/src/routes/index.tsx
@@ -12,7 +12,6 @@ import { analyses } from "~/lib/store";
 import { addAnalysis, AnalysisCard } from "~/components/Analysis";
 
 export default function Home() {
-  console.log(import.meta.env.SERVER_BASE_URL);
   return (
     <main class="text-center mx-auto text-gray-700 p-4">
       <h1 class="max-6-xs text-6xl text-sky-700 font-thin uppercase my-16">

--- a/apps/class-solid/src/routes/index.tsx
+++ b/apps/class-solid/src/routes/index.tsx
@@ -12,6 +12,7 @@ import { analyses } from "~/lib/store";
 import { addAnalysis, AnalysisCard } from "~/components/Analysis";
 
 export default function Home() {
+  console.log(import.meta.env.SERVER_BASE_URL);
   return (
     <main class="text-center mx-auto text-gray-700 p-4">
       <h1 class="max-6-xs text-6xl text-sky-700 font-thin uppercase my-16">

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "version": "0.0.1",
   "scripts": {
     "build": "turbo build",
     "dev": "turbo dev",

--- a/packages/class/package.json
+++ b/packages/class/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/class",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "exports": {
     "./class": "./src/class.ts",
     "./config": "./src/config.ts",


### PR DESCRIPTION
* Add an automated workflow to publish the class web app on GH pages on every release
* Bump version of class package and class web app to 0.0.1
* Fix build by updating the about page
* Update README

Followed examples from [here](https://usagi.io/articles/2024-04-28-deploying-a-solid-start-app-to-github-pages/) and [here](https://dev.to/lexlohr/deploy-a-solid-start-app-on-github-pages-2l2l)