### PR TITLE
Refactor experiments

### DIFF
--- a/apps/class-solid/src/components/Analysis.tsx
+++ b/apps/class-solid/src/components/Analysis.tsx
@@ -1,6 +1,6 @@
 import { For, Match, Switch, createUniqueId } from "solid-js";
 import { analyses, experiments, setAnalyses } from "~/lib/store";
-import type { Experiment } from "./Experiment";
+import type { Experiment } from "~/lib/store";
 import { MdiCog, MdiContentCopy, MdiDelete, MdiDownload } from "./icons";
 import { Button } from "./ui/button";
 import {

--- a/apps/class-solid/src/components/EditableText.tsx
+++ b/apps/class-solid/src/components/EditableText.tsx
@@ -28,12 +28,22 @@ export function EditableText(props: {
           props.onChange(formData.get("text") as string);
           setEditing(false);
         }}
+        onFocusOut={(e) => {
+          if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+            setEditing(false);
+          }
+        }}
       >
         <input
           name="text"
           type="text"
           value={props.text}
           class="mx-1 rounded border-2 bg-background p-1"
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              setEditing(false);
+            }
+          }}
         />
         <Button title="Save" type="submit" variant="ghost">
           🖉

--- a/apps/class-solid/src/components/EditableText.tsx
+++ b/apps/class-solid/src/components/EditableText.tsx
@@ -13,10 +13,7 @@ export function EditableText(props: {
       type="button"
       class={cn(props.class, "group")}
       title="Click to change"
-      onClick={(e) => {
-        // e.preventDefault();
-        setEditing(true);
-      }}
+      onClick={(e) => setEditing(true)}
     >
       {props.text}
       <span class="invisible ps-1 group-hover:visible">🖉</span>

--- a/apps/class-solid/src/components/EditableText.tsx
+++ b/apps/class-solid/src/components/EditableText.tsx
@@ -1,0 +1,47 @@
+import { Show, createSignal } from "solid-js";
+import { cn } from "~/lib/utils";
+import { Button } from "./ui/button";
+
+export function EditableText(props: {
+  text: string;
+  onChange: (text: string) => void;
+  class?: string;
+}) {
+  const [editing, setEditing] = createSignal(false);
+  const fallback = (
+    <button
+      type="button"
+      class={cn(props.class, "group")}
+      title="Click to change"
+      onClick={(e) => {
+        // e.preventDefault();
+        setEditing(true);
+      }}
+    >
+      {props.text}
+      <span class="invisible ps-1 group-hover:visible">🖉</span>
+    </button>
+  );
+  return (
+    <Show when={editing()} fallback={fallback}>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          const formData = new FormData(event.currentTarget);
+          props.onChange(formData.get("text") as string);
+          setEditing(false);
+        }}
+      >
+        <input
+          name="text"
+          type="text"
+          value={props.text}
+          class="mx-1 rounded border-2 bg-background p-1"
+        />
+        <Button title="Save" type="submit" variant="ghost">
+          🖉
+        </Button>
+      </form>
+    </Show>
+  );
+}

--- a/apps/class-solid/src/components/EditableText.tsx
+++ b/apps/class-solid/src/components/EditableText.tsx
@@ -39,6 +39,7 @@ export function EditableText(props: {
           type="text"
           value={props.text}
           class="mx-1 rounded border-2 bg-background p-1"
+          autofocus
           onKeyDown={(e) => {
             if (e.key === "Escape") {
               setEditing(false);
@@ -46,7 +47,7 @@ export function EditableText(props: {
           }}
         />
         <Button title="Save" type="submit" variant="ghost">
-          🖉
+          ✓
         </Button>
       </form>
     </Show>

--- a/apps/class-solid/src/components/Experiment.tsx
+++ b/apps/class-solid/src/components/Experiment.tsx
@@ -5,7 +5,10 @@ import {
   deleteExperiment,
   duplicateExperiment,
   modifyExperiment,
+  setExperimentDescription,
+  setExperimentName,
 } from "~/lib/store";
+import { EditableText } from "./EditableText";
 import { ExperimentConfigForm } from "./ExperimentConfigForm";
 import { MdiCog, MdiContentCopy, MdiDelete, MdiDownload } from "./icons";
 import {
@@ -60,11 +63,22 @@ export function ExperimentCard(experiment: Experiment) {
   return (
     <Card class="w-[380px]">
       <CardHeader>
-        {/* TODO: make name & description editable */}
-        <CardTitle>{experiment.name}</CardTitle>
+        <CardTitle>
+          <EditableText
+            text={experiment.name}
+            onChange={(name) => setExperimentName(experiment.id, name)}
+          />
+        </CardTitle>
         <CardDescription>{experiment.id}</CardDescription>
       </CardHeader>
-      <CardContent>{experiment.description}</CardContent>
+      <CardContent>
+        <EditableText
+          text={experiment.description}
+          onChange={(description) =>
+            setExperimentDescription(experiment.id, description)
+          }
+        />
+      </CardContent>
       <CardFooter>
         {/* TODO: implement download functionality */}
         <Button variant="outline">

--- a/apps/class-solid/src/components/Experiment.tsx
+++ b/apps/class-solid/src/components/Experiment.tsx
@@ -1,4 +1,4 @@
-import { createSignal } from "solid-js";
+import { Show, createSignal } from "solid-js";
 import { Button } from "~/components/ui/button";
 import {
   type Experiment,
@@ -30,7 +30,8 @@ import {
 } from "./ui/dialog";
 
 export function ExperimentSettingsDialog(experiment: Experiment) {
-  const [open, setOpen] = createSignal(true);
+  const [open, setOpen] = createSignal(experiment.output === undefined);
+
   return (
     <Dialog open={open()} onOpenChange={setOpen}>
       <DialogTrigger variant="outline" as={Button<"button">}>
@@ -59,6 +60,35 @@ export function ExperimentSettingsDialog(experiment: Experiment) {
   );
 }
 
+function RunningIndicator() {
+  return (
+    <div class="flex">
+      <svg
+        class="-ml-1 mr-3 h-5 w-5 animate-spin"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+      >
+        <title>Running</title>
+        <circle
+          class="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          stroke-width="4"
+        />
+        <path
+          class="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+        />
+      </svg>
+      <span>Running ...</span>
+    </div>
+  );
+}
+
 export function ExperimentCard(experiment: Experiment) {
   return (
     <Card class="w-[380px]">
@@ -80,20 +110,24 @@ export function ExperimentCard(experiment: Experiment) {
         />
       </CardContent>
       <CardFooter>
-        {/* TODO: implement download functionality */}
-        <Button variant="outline">
-          <MdiDownload />
-        </Button>
-        <ExperimentSettingsDialog {...experiment} />
-        <Button variant="outline">
-          <MdiContentCopy onClick={() => duplicateExperiment(experiment.id)} />
-        </Button>
-        <Button
-          variant="outline"
-          onClick={() => deleteExperiment(experiment.id)}
-        >
-          <MdiDelete />
-        </Button>
+        <Show when={!experiment.running} fallback={<RunningIndicator />}>
+          {/* TODO: implement download functionality */}
+          <Button variant="outline">
+            <MdiDownload />
+          </Button>
+          <ExperimentSettingsDialog {...experiment} />
+          <Button variant="outline">
+            <MdiContentCopy
+              onClick={() => duplicateExperiment(experiment.id)}
+            />
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => deleteExperiment(experiment.id)}
+          >
+            <MdiDelete />
+          </Button>
+        </Show>
       </CardFooter>
     </Card>
   );

--- a/apps/class-solid/src/components/Experiment.tsx
+++ b/apps/class-solid/src/components/Experiment.tsx
@@ -1,7 +1,8 @@
 import { type ClassConfig, classConfig } from "@classmodel/class/config";
-import { type ClassOutput, runClass } from "@classmodel/class/runner";
+import type { ClassOutput } from "@classmodel/class/runner";
 import { createSignal, createUniqueId } from "solid-js";
 import { Button } from "~/components/ui/button";
+import { runClass } from "~/lib/runner";
 import { experiments, setExperiments } from "~/lib/store";
 import { ExperimentConfigForm } from "./ExperimentConfigForm";
 import { MdiCog, MdiContentCopy, MdiDelete, MdiDownload } from "./icons";

--- a/apps/class-solid/src/components/Experiment.tsx
+++ b/apps/class-solid/src/components/Experiment.tsx
@@ -99,7 +99,9 @@ function DownloadExperiment(props: { experiment: Experiment }) {
       output: props.experiment.output,
     };
     return URL.createObjectURL(
-      new Blob([JSON.stringify(data, undefined, 2)], { type: "application/json" }),
+      new Blob([JSON.stringify(data, undefined, 2)], {
+        type: "application/json",
+      }),
     );
   });
 

--- a/apps/class-solid/src/components/Experiment.tsx
+++ b/apps/class-solid/src/components/Experiment.tsx
@@ -147,10 +147,11 @@ export function ExperimentCard(experiment: Experiment) {
         <Show when={!experiment.running} fallback={<RunningIndicator />}>
           <DownloadExperiment experiment={experiment} />
           <ExperimentSettingsDialog {...experiment} />
-          <Button variant="outline">
-            <MdiContentCopy
-              onClick={() => duplicateExperiment(experiment.id)}
-            />
+          <Button
+            variant="outline"
+            onClick={() => duplicateExperiment(experiment.id)}
+          >
+            <MdiContentCopy />
           </Button>
           <Button
             variant="outline"

--- a/apps/class-solid/src/components/Experiment.tsx
+++ b/apps/class-solid/src/components/Experiment.tsx
@@ -1,10 +1,11 @@
-import { type ClassConfig, classConfig } from "@classmodel/class/config";
-import type { ClassOutput } from "@classmodel/class/runner";
-import { createSignal, createUniqueId } from "solid-js";
-import { unwrap } from "solid-js/store";
+import { createSignal } from "solid-js";
 import { Button } from "~/components/ui/button";
-import { runClass } from "~/lib/runner";
-import { experiments, setExperiments } from "~/lib/store";
+import {
+  type Experiment,
+  deleteExperiment,
+  duplicateExperiment,
+  modifyExperiment,
+} from "~/lib/store";
 import { ExperimentConfigForm } from "./ExperimentConfigForm";
 import { MdiCog, MdiContentCopy, MdiDelete, MdiDownload } from "./icons";
 import {
@@ -24,55 +25,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "./ui/dialog";
-
-export interface Experiment {
-  name: string;
-  description: string;
-  id: string;
-  config: ClassConfig;
-  output: ClassOutput | undefined;
-}
-
-export async function runExperiment(id: string) {
-  const expProxy = experiments.find((exp) => exp.id === id);
-  if (!expProxy) {
-    throw new Error("No experiment with id {id}");
-  }
-  const exp = unwrap(expProxy);
-  const newOutput = await runClass(exp.config);
-  setExperiments((e) => e.id === exp.id, "output", newOutput);
-}
-
-export function addExperiment(config: ClassConfig = classConfig.parse({})) {
-  const id = createUniqueId();
-  const newExperiment: Experiment = {
-    name: "My experiment",
-    description: "Standard experiment",
-    id,
-    config,
-    output: undefined,
-  };
-  setExperiments(experiments.length, newExperiment);
-  return newExperiment;
-}
-
-export function duplicateExperiment(id: string) {
-  const newId = createUniqueId();
-  const original = unwrap(experiments.find((e) => e.id === id));
-  if (!original) {
-    throw new Error("No experiment with id {id}");
-  }
-  addExperiment(original.config);
-}
-
-function deleteExperiment(id: string) {
-  setExperiments(experiments.filter((exp) => exp.id !== id));
-}
-
-async function modifyExperiment(id: string, newConfig: ClassConfig) {
-  setExperiments((exp, i) => exp.id === id, "config", newConfig);
-  await runExperiment(id);
-}
 
 export function ExperimentSettingsDialog(experiment: Experiment) {
   const [open, setOpen] = createSignal(true);

--- a/apps/class-solid/src/components/ExperimentConfigForm.tsx
+++ b/apps/class-solid/src/components/ExperimentConfigForm.tsx
@@ -50,8 +50,8 @@ export function ExperimentConfigForm({
   onSubmit,
 }: {
   id: string;
-  config: ClassConfig;
-  onSubmit: (c: ClassConfig) => void;
+  config: Partial<ClassConfig>;
+  onSubmit: (c: Partial<ClassConfig>) => void;
 }) {
   return (
     <form
@@ -61,8 +61,10 @@ export function ExperimentConfigForm({
         const formData = new FormData(event.currentTarget);
         const rawData = Object.fromEntries(formData.entries());
         const nestedData = inflate(rawData);
+        // Parse only for validation
         const data = classConfig.parse(nestedData);
-        onSubmit(data);
+
+        onSubmit(nestedData);
       }}
     >
       <div class="grid grid-flow-col gap-1">

--- a/apps/class-solid/src/components/ExperimentConfigForm.tsx
+++ b/apps/class-solid/src/components/ExperimentConfigForm.tsx
@@ -65,13 +65,17 @@ export function ExperimentConfigForm({
         onSubmit(data);
       }}
     >
-      <ObjectField schema={ClassConfigJsonSchema} />
+      <ObjectField schema={ClassConfigJsonSchema} value={config} />
     </form>
   );
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: json schema types are too complex
-function ObjectField({ schema, name = "" }: { schema: any; name?: string }) {
+function ObjectField({
+  schema,
+  name = "",
+  value,
+  // biome-ignore lint/suspicious/noExplicitAny: json schema types are too complex
+}: { schema: any; name?: string; value?: any }) {
   // name can be empty, but only for root, which should be treated differently
   const isRoot = name === "";
 
@@ -83,6 +87,7 @@ function ObjectField({ schema, name = "" }: { schema: any; name?: string }) {
             // Nested fields should be connected with .
             name={isRoot ? `${propName}` : `${name}.${propName}`}
             schema={propSchema}
+            value={value?.[propName]}
           />
         )}
       </For>
@@ -104,25 +109,33 @@ function ObjectField({ schema, name = "" }: { schema: any; name?: string }) {
   );
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: json schema types are too complex
-function PropField({ name, schema }: { name: string; schema: any }) {
+function PropField({
+  name,
+  schema,
+  value,
+  // biome-ignore lint/suspicious/noExplicitAny: json schema types are too complex
+}: { name: string; schema: any; value: any }) {
   return (
     <Switch fallback={<p>Unknown type</p>}>
       <Match when={schema.type === "object"}>
-        <ObjectField name={name} schema={schema} />
+        <ObjectField name={name} schema={schema} value={value} />
       </Match>
       <Match when={schema.type === "number"}>
-        <MyTextField name={name} schema={schema} />
+        <MyTextField name={name} schema={schema} value={value} />
       </Match>
       <Match when={schema.type === "string"}>
-        <MyTextField name={name} schema={schema} />
+        <MyTextField name={name} schema={schema} value={value} />
       </Match>
     </Switch>
   );
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: json schema types are too complex
-function MyTextField({ name, schema }: { name: string; schema: any }) {
+function MyTextField({
+  name,
+  schema,
+  value,
+  // biome-ignore lint/suspicious/noExplicitAny: json schema types are too complex
+}: { name: string; schema: any; value: any }) {
   return (
     <TextField class="grid w-full max-w-sm items-center gap-1.5">
       <TextFieldLabel for={name}>{schema.description ?? name}</TextFieldLabel>
@@ -130,6 +143,7 @@ function MyTextField({ name, schema }: { name: string; schema: any }) {
         type="text"
         id={name}
         name={name}
+        value={value}
         placeholder={schema.default}
       />
     </TextField>

--- a/apps/class-solid/src/components/ExperimentConfigForm.tsx
+++ b/apps/class-solid/src/components/ExperimentConfigForm.tsx
@@ -65,7 +65,9 @@ export function ExperimentConfigForm({
         onSubmit(data);
       }}
     >
-      <ObjectField schema={ClassConfigJsonSchema} value={config} />
+      <div class="grid grid-flow-col gap-1">
+        <ObjectField schema={ClassConfigJsonSchema} value={config} />
+      </div>
     </form>
   );
 }

--- a/apps/class-solid/src/components/ui/dialog.tsx
+++ b/apps/class-solid/src/components/ui/dialog.tsx
@@ -56,7 +56,7 @@ const DialogContent = <T extends ValidComponent = "div">(
       <DialogOverlay />
       <DialogPrimitive.Content
         class={cn(
-          "-translate-x-1/2 -translate-y-1/2 data-[closed]:fade-out-0 data-[expanded]:fade-in-0 data-[closed]:zoom-out-95 data-[expanded]:zoom-in-95 data-[closed]:slide-out-to-left-1/2 data-[closed]:slide-out-to-top-[48%] data-[expanded]:slide-in-from-left-1/2 data-[expanded]:slide-in-from-top-[48%] fixed top-1/2 left-1/2 z-50 grid h-full w-full max-w-lg gap-4 overflow-auto border bg-background p-6 shadow-lg duration-200 data-[closed]:animate-out data-[expanded]:animate-in sm:rounded-lg",
+          "-translate-x-1/2 -translate-y-1/2 data-[closed]:fade-out-0 data-[expanded]:fade-in-0 data-[closed]:zoom-out-95 data-[expanded]:zoom-in-95 data-[closed]:slide-out-to-left-1/2 data-[closed]:slide-out-to-top-[48%] data-[expanded]:slide-in-from-left-1/2 data-[expanded]:slide-in-from-top-[48%] fixed top-1/2 left-1/2 z-50 grid max-h-full max-w-full gap-4 overflow-auto border bg-background p-6 shadow-lg duration-200 data-[closed]:animate-out data-[expanded]:animate-in sm:rounded-lg",
           props.class,
         )}
         {...rest}

--- a/apps/class-solid/src/lib/runner.ts
+++ b/apps/class-solid/src/lib/runner.ts
@@ -1,5 +1,5 @@
 import type { BmiClass } from "@classmodel/class/bmi";
-import type { ClassConfig } from "@classmodel/class/config";
+import { type ClassConfig, classConfig } from "@classmodel/class/config";
 import { wrap } from "comlink";
 
 const worker = new Worker(new URL("./worker.ts", import.meta.url), {
@@ -7,9 +7,10 @@ const worker = new Worker(new URL("./worker.ts", import.meta.url), {
 });
 export const AsyncBmiClass = wrap<typeof BmiClass>(worker);
 
-export async function runClass(config: ClassConfig) {
+export async function runClass(config: Partial<ClassConfig>) {
+  const parsedConfig: ClassConfig = classConfig.parse(config);
   const model = await new AsyncBmiClass();
-  await model.initialize(config);
+  await model.initialize(parsedConfig);
   const output = await model.run({
     var_names: ["h"],
   });

--- a/apps/class-solid/src/lib/store.ts
+++ b/apps/class-solid/src/lib/store.ts
@@ -1,6 +1,58 @@
-import { createStore } from "solid-js/store";
+import type { ClassConfig } from "@classmodel/class/config";
+import { classConfig } from "@classmodel/class/config";
+import type { ClassOutput } from "@classmodel/class/runner";
+import { createUniqueId } from "solid-js";
+import { createStore, unwrap } from "solid-js/store";
 import type { Analysis } from "~/components/Analysis";
-import type { Experiment } from "~/components/Experiment";
+import { runClass } from "./runner";
+
+export interface Experiment {
+  name: string;
+  description: string;
+  id: string;
+  config: ClassConfig;
+  output: ClassOutput | undefined;
+}
+
+export async function runExperiment(id: string) {
+  const expProxy = experiments.find((exp) => exp.id === id);
+  if (!expProxy) {
+    throw new Error("No experiment with id {id}");
+  }
+  const exp = unwrap(expProxy);
+  const newOutput = await runClass(exp.config);
+  setExperiments((e) => e.id === exp.id, "output", newOutput);
+}
+
+export function addExperiment(config: ClassConfig = classConfig.parse({})) {
+  const id = createUniqueId();
+  const newExperiment: Experiment = {
+    name: "My experiment",
+    description: "Standard experiment",
+    id,
+    config,
+    output: undefined,
+  };
+  setExperiments(experiments.length, newExperiment);
+  return newExperiment;
+}
+
+export function duplicateExperiment(id: string) {
+  const original = unwrap(experiments.find((e) => e.id === id));
+  if (!original) {
+    throw new Error("No experiment with id {id}");
+  }
+  addExperiment(original.config);
+}
+
+export function deleteExperiment(id: string) {
+  setExperiments(experiments.filter((exp) => exp.id !== id));
+}
+
+export async function modifyExperiment(id: string, newConfig: ClassConfig) {
+  setExperiments((exp, i) => exp.id === id, "config", newConfig);
+  await runExperiment(id);
+}
 
 export const [experiments, setExperiments] = createStore<Experiment[]>([]);
 export const [analyses, setAnalyses] = createStore<Analysis[]>([]);

--- a/apps/class-solid/src/lib/store.ts
+++ b/apps/class-solid/src/lib/store.ts
@@ -27,7 +27,7 @@ export const [analyses, setAnalyses] = createStore<Analysis[]>([]);
 export async function runExperiment(id: string) {
   const expProxy = experiments.find((exp) => exp.id === id);
   if (!expProxy) {
-    throw new Error("No experiment with id {id}");
+    throw new Error(`No experiment with id ${id}`);
   }
   const exp = unwrap(expProxy);
   const newOutput = await runClass(exp.config);

--- a/apps/class-solid/src/lib/store.ts
+++ b/apps/class-solid/src/lib/store.ts
@@ -1,7 +1,7 @@
 import type { ClassConfig } from "@classmodel/class/config";
 import { classConfig } from "@classmodel/class/config";
 import type { ClassOutput } from "@classmodel/class/runner";
-import { createUniqueId } from "solid-js";
+import { createSignal } from "solid-js";
 import { createStore, unwrap } from "solid-js/store";
 import type { Analysis } from "~/components/Analysis";
 import { runClass } from "./runner";
@@ -14,6 +14,16 @@ export interface Experiment {
   output: ClassOutput | undefined;
 }
 
+let lastExperimentId = 0;
+
+function bumpLastExperimentId(): string {
+  lastExperimentId++;
+  return lastExperimentId.toString();
+}
+
+export const [experiments, setExperiments] = createStore<Experiment[]>([]);
+export const [analyses, setAnalyses] = createStore<Analysis[]>([]);
+
 export async function runExperiment(id: string) {
   const expProxy = experiments.find((exp) => exp.id === id);
   if (!expProxy) {
@@ -25,11 +35,11 @@ export async function runExperiment(id: string) {
 }
 
 export function addExperiment(config: ClassConfig = classConfig.parse({})) {
-  const id = createUniqueId();
+  const id = bumpLastExperimentId();
   const newExperiment: Experiment = {
     name: "My experiment",
     description: "Standard experiment",
-    id,
+    id: id.toString(),
     config,
     output: undefined,
   };
@@ -54,5 +64,10 @@ export async function modifyExperiment(id: string, newConfig: ClassConfig) {
   await runExperiment(id);
 }
 
-export const [experiments, setExperiments] = createStore<Experiment[]>([]);
-export const [analyses, setAnalyses] = createStore<Analysis[]>([]);
+export function setExperimentName(id: string, newName: string) {
+  setExperiments((exp) => exp.id === id, "name", newName);
+}
+
+export function setExperimentDescription(id: string, newDescription: string) {
+  setExperiments((exp) => exp.id === id, "description", newDescription);
+}

--- a/apps/class-solid/src/lib/store.ts
+++ b/apps/class-solid/src/lib/store.ts
@@ -1,7 +1,6 @@
 import type { ClassConfig } from "@classmodel/class/config";
 import { classConfig } from "@classmodel/class/config";
 import type { ClassOutput } from "@classmodel/class/runner";
-import { createSignal } from "solid-js";
 import { createStore, unwrap } from "solid-js/store";
 import type { Analysis } from "~/components/Analysis";
 import { runClass } from "./runner";

--- a/apps/class-solid/src/lib/store.ts
+++ b/apps/class-solid/src/lib/store.ts
@@ -1,5 +1,4 @@
 import type { ClassConfig } from "@classmodel/class/config";
-import { classConfig } from "@classmodel/class/config";
 import type { ClassOutput } from "@classmodel/class/runner";
 import { createStore, produce, unwrap } from "solid-js/store";
 import type { Analysis } from "~/components/Analysis";
@@ -9,7 +8,7 @@ export interface Experiment {
   name: string;
   description: string;
   id: string;
-  config: ClassConfig;
+  config: Partial<ClassConfig>;
   output: ClassOutput | undefined;
   running: boolean;
 }
@@ -49,7 +48,7 @@ export async function runExperiment(id: string) {
   );
 }
 
-export function addExperiment(config: ClassConfig = classConfig.parse({})) {
+export function addExperiment(config: Partial<ClassConfig> = {}) {
   const id = bumpLastExperimentId();
   const newExperiment: Experiment = {
     name: `My experiment ${id}`,
@@ -68,14 +67,17 @@ export function duplicateExperiment(id: string) {
   if (!original) {
     throw new Error("No experiment with id {id}");
   }
-  addExperiment(original.config);
+  addExperiment({ ...original.config });
 }
 
 export function deleteExperiment(id: string) {
   setExperiments(experiments.filter((exp) => exp.id !== id));
 }
 
-export async function modifyExperiment(id: string, newConfig: ClassConfig) {
+export async function modifyExperiment(
+  id: string,
+  newConfig: Partial<ClassConfig>,
+) {
   setExperiments((exp, i) => exp.id === id, "config", newConfig);
   await runExperiment(id);
 }

--- a/apps/class-solid/src/routes/index.tsx
+++ b/apps/class-solid/src/routes/index.tsx
@@ -1,11 +1,7 @@
 import { For, Show } from "solid-js";
 
 import { AnalysisCard, addAnalysis } from "~/components/Analysis";
-import {
-  AddCustomExperiment,
-  ExperimentCard,
-  addDefaultExperiment,
-} from "~/components/Experiment";
+import { ExperimentCard, addExperiment } from "~/components/Experiment";
 import { Button } from "~/components/ui/button";
 import { Flex } from "~/components/ui/flex";
 
@@ -26,12 +22,9 @@ export default function Home() {
         </For>
         <div>
           <div>
-            <Button variant="outline" size="lg" onClick={addDefaultExperiment}>
-              Add default experiment
+            <Button variant="outline" size="lg" onClick={addExperiment}>
+              Add experiment
             </Button>
-          </div>
-          <div>
-            <AddCustomExperiment />
           </div>
           <div>
             <Button variant="outline" size="lg">

--- a/apps/class-solid/src/routes/index.tsx
+++ b/apps/class-solid/src/routes/index.tsx
@@ -16,7 +16,7 @@ export default function Home() {
       </h1>
 
       <h2 class="my-8 text-4xl">Experiments</h2>
-      <Flex justifyContent="center" class="gap-4">
+      <Flex justifyContent="center" class="flex-wrap gap-4">
         <For each={experiments}>
           {(experiment) => ExperimentCard(experiment)}
         </For>
@@ -41,7 +41,7 @@ export default function Home() {
 
       <h2 class="my-8 text-4xl">Analysis</h2>
       <Show when={experiments.length} fallback={<p>Add an experiment first</p>}>
-        <Flex justifyContent="center" class="gap-4">
+        <Flex justifyContent="center" class="flex-wrap gap-4">
           <For each={analyses}>{(analysis) => AnalysisCard(analysis)}</For>
           <div>
             <div>

--- a/apps/class-solid/src/routes/index.tsx
+++ b/apps/class-solid/src/routes/index.tsx
@@ -22,7 +22,7 @@ export default function Home() {
         </For>
         <div>
           <div>
-            <Button variant="outline" size="lg" onClick={addExperiment}>
+            <Button variant="outline" size="lg" onClick={() => addExperiment()}>
               Add experiment
             </Button>
           </div>

--- a/apps/class-solid/src/routes/index.tsx
+++ b/apps/class-solid/src/routes/index.tsx
@@ -1,11 +1,11 @@
 import { For, Show } from "solid-js";
 
 import { AnalysisCard, addAnalysis } from "~/components/Analysis";
-import { ExperimentCard, addExperiment } from "~/components/Experiment";
+import { ExperimentCard } from "~/components/Experiment";
 import { Button } from "~/components/ui/button";
 import { Flex } from "~/components/ui/flex";
 
-import { experiments } from "~/lib/store";
+import { addExperiment, experiments } from "~/lib/store";
 import { analyses } from "~/lib/store";
 
 export default function Home() {

--- a/biome.json
+++ b/biome.json
@@ -7,6 +7,9 @@
     "enabled": true,
     "rules": {
       "recommended": true,
+      "correctness": {
+        "noUnusedImports": "error"
+      },
       "nursery": {
         "useSortedClasses": {
           "level": "warn",


### PR DESCRIPTION
* Initiate experiments without output
* Combine default + custom experiment into a single "add experiment" button
* Add experiment always opens configuration form, and experiment is executed upon form submit; then output is updated

Also: 
* Implement `modify experiment` functionality
* Implement `duplicate experiment` functionality
* Use async runner again, somehow that got messed up in merging previous PRs that were done in parallel.

Todo:
* I'm not loving the ModifyExperiment component, since it has the trigger inside it. That means the trigger is associated with a UI element (in this case the COG wheel). I'm not sure if/how it can be toggled from outside, e.g. by the `addExperiment` js function. Now, dialogs are open by default, it would be nicer if they would be closed by default. 
* Also, we have lots of invisible dialogs, one for each trigger. I wonder if it would be nicer to have only one dialog but populate it with different settings depending on where it is triggered.
* Bit out of scope, but it would be nice if the timeseries plot is reactive, i.e. responds to updates in the experiments store.

Fixes #12 