### PR TITLE
Put name/title and description inside json schemas

### DIFF
--- a/apps/class-solid/package.json
+++ b/apps/class-solid/package.json
@@ -28,8 +28,7 @@
     "tailwind-merge": "^2.4.0",
     "tailwindcss": "^3.4.4",
     "tailwindcss-animate": "^1.0.7",
-    "vinxi": "^0.3.14",
-    "zod": "^3.23.8"
+    "vinxi": "^0.3.14"
   },
   "engines": {
     "node": ">=18"

--- a/apps/class-solid/src/components/Analysis.tsx
+++ b/apps/class-solid/src/components/Analysis.tsx
@@ -54,14 +54,14 @@ export function TimeSeriesPlot() {
         .flatMap((e) => {
           const permutationRuns = e.permutations.map((perm) => {
             return {
-              label: `${e.name}/${perm.name}`,
+              label: `${e.reference.title}/${perm.title}`,
               data: perm.output === undefined ? [null] : perm.output.h,
               fill: false,
             };
           });
           return [
             {
-              label: e.name,
+              label: e.reference.title,
               data:
                 e.reference.output === undefined
                   ? [null]
@@ -89,14 +89,14 @@ function FinalHeights() {
         return (
           <div class="mb-2">
             <p>
-              {experiment.name}: {h.toFixed()} m
+              {experiment.reference.title}: {h.toFixed()} m
             </p>
             <For each={experiment.permutations}>
               {(perm) => {
                 const h = perm.output?.h[perm.output.h.length - 1] || 0;
                 return (
                   <p>
-                    {experiment.name}/{perm.name}: {h.toFixed()} m
+                    {experiment.reference.title}/{perm.title}: {h.toFixed()} m
                   </p>
                 );
               }}

--- a/apps/class-solid/src/components/Experiment.tsx
+++ b/apps/class-solid/src/components/Experiment.tsx
@@ -48,9 +48,10 @@ export function AddExperimentDialog(props: {
 }) {
   const initialExperiment = () => {
     return {
-      name: `My experiment ${props.nextIndex}`,
-      description: "",
-      reference: { config: {} },
+      reference: {
+        title: `My experiment ${props.nextIndex}`,
+        description: "",
+      },
       permutations: [],
       running: false,
     };
@@ -73,12 +74,7 @@ export function AddExperimentDialog(props: {
           experiment={initialExperiment()}
           onSubmit={(newConfig) => {
             props.onClose();
-            const { title, description, ...strippedConfig } = newConfig;
-            addExperiment(
-              strippedConfig,
-              title ?? initialExperiment().name,
-              description ?? initialExperiment().description,
-            );
+            addExperiment(newConfig);
           }}
         />
         <DialogFooter>
@@ -111,13 +107,7 @@ export function ExperimentSettingsDialog(props: {
           experiment={props.experiment}
           onSubmit={(newConfig) => {
             setOpen(false);
-            const { title, description, ...strippedConfig } = newConfig;
-            modifyExperiment(
-              props.experimentIndex,
-              strippedConfig,
-              title ?? props.experiment.name,
-              description ?? props.experiment.description,
-            );
+            modifyExperiment(props.experimentIndex, newConfig);
           }}
         />
         <DialogFooter>
@@ -168,7 +158,7 @@ function DownloadExperimentConfiguration(props: { experiment: Experiment }) {
     URL.revokeObjectURL(downloadUrl());
   });
 
-  const filename = `class-${props.experiment.name}.json`;
+  const filename = `class-${props.experiment.reference.title}.json`;
   return (
     <a href={downloadUrl()} download={filename} type="application/json">
       Configuration
@@ -185,7 +175,7 @@ function DownloadExperimentArchive(props: { experiment: Experiment }) {
     onCleanup(() => URL.revokeObjectURL(objectUrl));
   });
 
-  const filename = `class-${props.experiment.name}.zip`;
+  const filename = `class-${props.experiment.reference.title}.zip`;
   return (
     <a href={url()} download={filename} type="application/json">
       Config + output
@@ -223,8 +213,8 @@ export function ExperimentCard(props: {
   return (
     <Card class="w-[380px]">
       <CardHeader>
-        <CardTitle>{experiment().name}</CardTitle>
-        <CardDescription>{experiment().description}</CardDescription>
+        <CardTitle>{experiment().reference.title}</CardTitle>
+        <CardDescription>{experiment().reference.description}</CardDescription>
       </CardHeader>
       <CardContent>
         <PermutationsList

--- a/apps/class-solid/src/components/ExperimentConfigForm.tsx
+++ b/apps/class-solid/src/components/ExperimentConfigForm.tsx
@@ -1,7 +1,7 @@
 import { pruneDefaults } from "@classmodel/class/validate";
 import { type SubmitHandler, createForm } from "@modular-forms/solid";
 import { createMemo } from "solid-js";
-import type { Experiment } from "~/lib/store";
+import { type Experiment, stripOutput } from "~/lib/store";
 import {
   type NamedConfig,
   jsonSchemaOfNamedConfig,
@@ -20,11 +20,7 @@ export function ExperimentConfigForm({
   onSubmit: (c: NamedConfig) => void;
 }) {
   const initialValues = createMemo(() => {
-    return {
-      title: experiment.name,
-      description: experiment.description,
-      ...pruneDefaults(experiment.reference.config),
-    };
+    return pruneDefaults(stripOutput(experiment.reference));
   });
   const [_, { Form, Field }] = createForm<NamedConfig>({
     initialValues: initialValues(),
@@ -34,6 +30,7 @@ export function ExperimentConfigForm({
   const handleSubmit: SubmitHandler<NamedConfig> = (values, event) => {
     // Use validate to coerce strings to numbers
     validate(values);
+
     onSubmit(values);
   };
 
@@ -42,12 +39,11 @@ export function ExperimentConfigForm({
       id={id}
       onSubmit={handleSubmit}
       shouldActive={false} // Also return from collapsed fields
-      shouldDirty={true} // Don't return empty strings for unset fields
     >
       <div>
         <ObjectField
           schema={jsonSchemaOfNamedConfig}
-          value={pruneDefaults(experiment.reference.config)}
+          value={initialValues}
           Field={Field}
         />
       </div>

--- a/apps/class-solid/src/components/ObjectField.tsx
+++ b/apps/class-solid/src/components/ObjectField.tsx
@@ -1,5 +1,5 @@
 import type { JSONSchemaType } from "ajv";
-import { For, Match, Show, Switch, splitProps } from "solid-js";
+import { For, Match, Show, Switch, createMemo, splitProps } from "solid-js";
 import {
   TextField,
   TextFieldDescription,
@@ -22,12 +22,18 @@ export function ObjectField<S>({
   Field,
   // biome-ignore lint/suspicious/noExplicitAny: json schema types are too complex
 }: { schema: JSONSchemaType<S>; name?: string; value?: any; Field: any }) {
+  if (schema === undefined) {
+    return null;
+  }
   // name can be empty, but only for root, which should be treated differently
   const isRoot = name === "";
 
   function Children() {
+    const props = createMemo(() => {
+      return Object.entries(schema.properties);
+    });
     return (
-      <For each={Object.entries(schema.properties)}>
+      <For each={props()}>
         {([propName, propSchema]) => (
           <PropField
             // Nested fields should be connected with .
@@ -79,7 +85,7 @@ function PropField({
   // biome-ignore lint/suspicious/noExplicitAny: json schema types are too complex
 }: { name: string; schema: any; value: any; Field: any }) {
   return (
-    <Switch fallback={<p>Unknown type</p>}>
+    <Switch fallback={<p>Unknown type of {schema}</p>}>
       <Match when={schema.type === "object"}>
         <ObjectField name={name} schema={schema} value={value} Field={Field} />
       </Match>

--- a/packages/class/src/validate.ts
+++ b/packages/class/src/validate.ts
@@ -82,18 +82,30 @@ export function pruneDefaults(config: PartialConfig): PartialConfig {
     if (typeof value === "object") {
       for (const [subKey, subValue] of Object.entries(value)) {
         const defaultParent = defaultConfig[tkey];
-        const defaultValue =
-          defaultParent[subKey as keyof typeof defaultParent];
-        if (subValue !== defaultValue) {
-          if (!newConfig[tkey]) {
-            newConfig[tkey] = {};
+        if (defaultParent === undefined) {
+        } else {
+          const defaultValue =
+            defaultParent[subKey as keyof typeof defaultParent];
+          if (subValue !== defaultValue) {
+            if (!newConfig[tkey]) {
+              newConfig[tkey] = {};
+            }
+            (newConfig[tkey] as Record<string, unknown>)[subKey] = subValue;
           }
-          (newConfig[tkey] as Record<string, unknown>)[subKey] = subValue;
+        }
+      }
+    } else {
+      const defaultParent = defaultConfig[tkey];
+      if (defaultParent === undefined) {
+        newConfig[tkey] = value;
+      } else {
+        const defaultValue = defaultParent[tkey as keyof typeof defaultParent];
+        if (value !== defaultValue) {
+          newConfig[tkey] = value;
         }
       }
     }
   }
-
   return newConfig;
 }
 
@@ -139,6 +151,9 @@ export function overwriteDefaultsInJsonSchema<C>(
     const val = defaults[key as keyof RecursivePartial<C>];
     for (const subkey in val) {
       const subval = val[subkey as keyof typeof val];
+      if (newSchema.properties[key as keyof C].properties === undefined) {
+        continue;
+      }
       const prop =
         newSchema.properties[key as keyof C].properties[
           subkey as keyof typeof val

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,9 +74,6 @@ importers:
       vinxi:
         specifier: ^0.3.14
         version: 0.3.14(@types/node@20.14.10)(ioredis@5.4.1)(sass@1.77.6)(terser@5.31.2)
-      zod:
-        specifier: ^3.23.8
-        version: 3.23.8
     devDependencies:
       '@playwright/test':
         specifier: ^1.45.3


### PR DESCRIPTION
Changes experiment store shape from

```
{
  name,
  description,
  reference: {
     config
     output
  },
  permutations[0]: {
    name,
    config ,
    output
  },
  running
}
```

to 

```
{
  reference: {
     title,
    description,
     ...config,
    output
  },
 permutations[0]: {
     title,
    description,
     ...config,
    output
  },
  running
}
```

TODO

- [x] drop zod
- [ ] I dont like that output is on same level as title, description config.
