### PR TITLE
Cli with deno

### DIFF
--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,0 +1,2 @@
+class
+config.json

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,21 @@
+# Class cli
+
+## Usage
+
+```shell
+deno --allow-read main.ts config.json 
+```
+
+## Compiled executable
+
+```shell
+deno compile --allow-read -o class main.ts
+ls -lnh class 
+-rwxr-xr-x 1 1000 1000 84M Oct 11 18:38 class
+```
+
+Run with
+
+```shell
+./class config.json
+```

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,0 +1,10 @@
+{
+  "name": "@classmodel/cli",
+  "version": "0.0.3",
+  "tasks": {
+    "dev": "deno run --watch main.ts"
+  },
+  "imports": {
+    "@classmodel/class": "jsr:@classmodel/class@^0.0.3"
+  }
+}

--- a/packages/cli/deno.lock
+++ b/packages/cli/deno.lock
@@ -1,0 +1,45 @@
+{
+  "version": "4",
+  "specifiers": {
+    "jsr:@classmodel/class@^0.0.3": "0.0.3",
+    "jsr:@std/assert@1": "1.0.6",
+    "jsr:@std/internal@^1.0.4": "1.0.4",
+    "npm:zod-to-json-schema@^3.23.1": "3.23.3_zod@3.23.8",
+    "npm:zod@^3.23.8": "3.23.8"
+  },
+  "jsr": {
+    "@classmodel/class@0.0.3": {
+      "integrity": "02d95779a477a2b64d9ad95bffd38aa95efec37091b4c6a702357078ce720adf",
+      "dependencies": [
+        "npm:zod",
+        "npm:zod-to-json-schema"
+      ]
+    },
+    "@std/assert@1.0.6": {
+      "integrity": "1904c05806a25d94fe791d6d883b685c9e2dcd60e4f9fc30f4fc5cf010c72207",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.4": {
+      "integrity": "62e8e4911527e5e4f307741a795c0b0a9e6958d0b3790716ae71ce085f755422"
+    }
+  },
+  "npm": {
+    "zod-to-json-schema@3.23.3_zod@3.23.8": {
+      "integrity": "sha512-TYWChTxKQbRJp5ST22o/Irt9KC5nj7CdBKYB/AosCRdj/wxEMvv4NNaj9XVUHDOIp53ZxArGhnw5HMZziPFjog==",
+      "dependencies": [
+        "zod"
+      ]
+    },
+    "zod@3.23.8": {
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@classmodel/class@^0.0.3",
+      "jsr:@std/assert@1"
+    ]
+  }
+}

--- a/packages/cli/main.ts
+++ b/packages/cli/main.ts
@@ -1,0 +1,25 @@
+import { classConfig } from "@classmodel/class/config";
+import { runClass } from "@classmodel/class/runner";
+
+function main(args: string[], logger = console) {
+  if (args.length !== 1) {
+    console.error("Usage: class <config-file.json>");
+    Deno.exit(1);
+  }
+  try {
+    const configFile = args[0];
+    const configAsString = Deno.readTextFileSync(configFile);
+    const rawConfig = JSON.parse(configAsString);
+    const config = classConfig.parse(rawConfig);
+    const output = runClass(config);
+    logger.log(JSON.stringify(output, null, 2));
+  } catch (error) {
+    logger.error("Error running class:", error);
+    Deno.exit(1);
+  }
+}
+
+// Learn more at https://docs.deno.com/runtime/manual/examples/module_metadata#concepts
+if (import.meta.main) {
+  main(Deno.args);
+}


### PR DESCRIPTION
Refs #51

TODO

- [x] cli
- [x] compile
- [ ] remove stuff done in #57 
- [ ] happy inside monorepo
  - [ ] scripts in root
- [ ] ci workflow to test cli and compiled executable
- [ ] ci workflow on release to compile executable and add to release
- [ ] improve usage message
- [ ] improve error message
- [ ] allow to use class package from workspace instead of from jsr
- [ ] nice to haves
  - [ ] allow to read config from stdin
  - [ ] allow to write outout to stdout
  - [ ] add `--help` flag
  - [ ] add subcommand to validate config.json file
  - [ ] add subcommand to run experiment aka reference config and permutations configs
  - [ ] add output format csv or tsv instead of just json