### PR TITLE
Bugfix 86

### DIFF
--- a/apps/class-solid/src/components/Analysis.tsx
+++ b/apps/class-solid/src/components/Analysis.tsx
@@ -176,7 +176,7 @@ export function VerticalProfilePlot({
 
   // TODO: better to include jump at top in extent calculation rather than adding random margin.
   const xLim = () => getNiceAxisLimits(allValues(), 1);
-  const yLim = () => getNiceAxisLimits(allHeights(), 0);
+  const yLim = () => [0, getNiceAxisLimits(allHeights(), 0)[1]];
   const profileData = () =>
     flatExperiments().map((e) => {
       const { config, output, ...formatting } = e;
@@ -248,8 +248,6 @@ function TimeSlider(
     const max = maxValue();
     if (time() > max && max !== -1) {
       setTime(maxValue());
-      console.log(maxValue());
-      console.log(time());
     }
   });
   return (

--- a/apps/class-solid/src/components/Analysis.tsx
+++ b/apps/class-solid/src/components/Analysis.tsx
@@ -176,7 +176,8 @@ export function VerticalProfilePlot({
 
   // TODO: better to include jump at top in extent calculation rather than adding random margin.
   const xLim = () => getNiceAxisLimits(allValues(), 1);
-  const yLim = () => [0, getNiceAxisLimits(allHeights(), 0)[1]];
+  const yLim = () =>
+    [0, getNiceAxisLimits(allHeights(), 0)[1]] as [number, number];
   const profileData = () =>
     flatExperiments().map((e) => {
       const { config, output, ...formatting } = e;

--- a/apps/class-solid/src/components/plots/Axes.tsx
+++ b/apps/class-solid/src/components/plots/Axes.tsx
@@ -87,6 +87,10 @@ export function getNiceAxisLimits(
   const max = Math.max(...data);
   const min = Math.min(...data);
   const range = max - min;
+
+  // Avoid NaNs on axis for constant values
+  if (range === 0) return [min - 1, max + 1];
+
   const step = 10 ** Math.floor(Math.log10(range));
 
   const niceMin = Math.floor(min / step) * step - extraMargin * step;

--- a/apps/class-solid/src/lib/profiles.ts
+++ b/apps/class-solid/src/lib/profiles.ts
@@ -18,7 +18,6 @@ export function getVerticalProfiles(
   const height = output.h.slice(t)[0];
   const dh = 1600; // how much free troposphere to display?
   const hProfile = [0, height, height, height + dh];
-
   if (variable === "theta") {
     // Extract potential temperature profile
     const theta = output.theta.slice(t)[0];

--- a/packages/class/src/bmi.ts
+++ b/packages/class/src/bmi.ts
@@ -34,7 +34,18 @@ interface BmiLight<Config> {
   get_grid_type(): string;
 }
 
-const ouput_var_names: string[] = ["h", "theta", "dtheta", "q", "dq"] as const;
+const ouput_var_names: string[] = [
+  "h",
+  "theta",
+  "dtheta",
+  "q",
+  "dq",
+  "dthetav",
+  "we",
+  "ws",
+  "wthetave",
+  "wthetav",
+] as const;
 
 /**
  * Class representing a BMI (Basic Model Interface) implementation for the CLASS model.
@@ -134,8 +145,7 @@ export class BmiClass implements BmiLight<Config> {
   }): { t: number[] } & { [K in T[number]]: number[] } {
     const output: { t: number[] } & { [K in T[number]]: number[] } =
       Object.fromEntries([["t", []], ...var_names.map((name) => [name, []])]);
-    while (this.model.t < this.config.timeControl.runtime) {
-      this.update();
+    while (this.model.t <= this.config.timeControl.runtime) {
       if (this.model.t % freq === 0) {
         output.t.push(this.model.t);
         for (const name of var_names) {
@@ -145,6 +155,7 @@ export class BmiClass implements BmiLight<Config> {
         // TODO progress callback?
         // Initial attempt failed with "could not be cloned" error
       }
+      this.update();
     }
     return output;
   }

--- a/packages/class/src/class.ts
+++ b/packages/class/src/class.ts
@@ -81,7 +81,7 @@ export class CLASS {
   /** Tendency of specific humidity jump at h[kg kg-1 s-1] */
   get dqtend(): number {
     const w_q_ft = 0; // TODO: add free troposphere switch
-    return this._cfg.mixedLayer.gammaq - this.qtend + w_q_ft;
+    return this._cfg.mixedLayer.gammaq * this.we - this.qtend + w_q_ft;
   }
 
   /** Entrainment velocity [m s-1]. */


### PR DESCRIPTION
Fixes #86
Fixes #97 
Also adds the initial time to the output data
Also adds some model internal variables to output to help debug - this needs to addressed more comprehensively in #94 


NaNs on axes were caused by a constant value of `h`. 

Now, setting initial jump to very small value leads to rapid heating of PBL. There is not growth at all because `dthetav` is initally negative with these settings and remains so as the PBL heats up.

![image](https://github.com/user-attachments/assets/70784356-94da-471d-9398-2ba7e8ef85a1)
