### PR TITLE
Running a python model instead

### DIFF
--- a/apps/class-solid/public/python/bmi_class.py
+++ b/apps/class-solid/public/python/bmi_class.py
@@ -1,70 +1,96 @@
+# class BmiClass:
+#     def __init__(self):
+#         self.config = {}
+#         self.model = None
+#         print("CLASS instantiated!")
+
+#     def initialize(self, config: dict):
+#         # from class_model import CLASS
+
+#         self.config = config
+#         self.model = CLASS(config)
+#         print("CLASS initialized!")
+
+#     def update(self):
+#         self.model.update()
+
+#     def get_component_name(self):
+#         return "Chemistry Land-surface Atmosphere Soil Slab model"
+
+#     def get_output_item_count(self):
+#         return len(self.get_output_var_names())
+
+#     def get_output_var_names(self):
+#         return ["h", "theta", "dtheta", "q", "dq"]
+
+#     def get_var_grid(self, name: str):
+#         return 1
+
+#     def get_var_type(self, name: str):
+#         return "float"
+
+#     def get_var_location(self, name: str):
+#         return "node"
+
+#     def get_current_time(self):
+#         return self.model.t
+
+#     def get_end_time(self):
+#         return self.config["timeControl"]["runtime"]
+
+#     def get_time_units(self):
+#         return "s"
+
+#     def get_time_step(self):
+#         return self.config["timeControl"]["dt"]
+
+#     def get_value(self, name: str):
+#         if name in self.get_output_var_names():
+#             return [getattr(self.model, name)]
+#         raise ValueError(f"Variable {name} not found")
+
+#     def get_grid_type(self):
+#         return "scalar"
+
+#     def run(self, freq=600, var_names=None):
+#         if var_names is None:
+#             var_names = self.get_output_var_names()
+
+#         output = {"t": []}
+#         for name in var_names:
+#             output[name] = []
+
+#         while self.model.t <= self.config["timeControl"]["runtime"]:
+#             if self.model.t % freq == 0:
+#                 output["t"].append(self.model.t)
+#                 for name in var_names:
+#                     output[name].append(getattr(self.model, name))
+#             self.update()
+
+#         return output
+
+class SubClass:
+    def __init__(self):
+        self.value = 42
+
 class BmiClass:
     def __init__(self):
-        self.config = {}
+        print("BmiClass in python instantiated")
         self.model = None
-        print("CLASS instantiated!")
-
-    def initialize(self, config: dict):
-        # from class_model import CLASS
-
-        self.config = config
-        self.model = CLASS(config)
-        print("CLASS initialized!")
-
-    def update(self):
-        self.model.update()
 
     def get_component_name(self):
         return "Chemistry Land-surface Atmosphere Soil Slab model"
 
-    def get_output_item_count(self):
-        return len(self.get_output_var_names())
+    def initialize(self, cfg: dict):
+        # Instantiate another class (SubClass) here
+        self.model = SubClass()
+
+    def get_value(self, var: str):
+        return self.model.value
 
     def get_output_var_names(self):
         return ["h", "theta", "dtheta", "q", "dq"]
 
-    def get_var_grid(self, name: str):
-        return 1
-
-    def get_var_type(self, name: str):
-        return "float"
-
-    def get_var_location(self, name: str):
-        return "node"
-
-    def get_current_time(self):
-        return self.model.t
-
-    def get_end_time(self):
-        return self.config["timeControl"]["runtime"]
-
-    def get_time_units(self):
-        return "s"
-
-    def get_time_step(self):
-        return self.config["timeControl"]["dt"]
-
-    def get_value(self, name: str):
-        if name in self.get_output_var_names():
-            return [getattr(self.model, name)]
-        raise ValueError(f"Variable {name} not found")
-
-    def get_grid_type(self):
-        return "scalar"
-
-    def run(self, freq=600, var_names=None):
-        if var_names is None:
-            var_names = self.get_output_var_names()
-
+    def run(self, var_names=["t"]):
         output = {"t": []}
-        for name in var_names:
-            output[name] = []
-
-        while self.model.t <= self.config["timeControl"]["runtime"]:
-            if self.model.t % freq == 0:
-                output["t"].append(self.model.t)
-                for name in var_names:
-                    output[name].append(getattr(self.model, name))
-            self.update()
-
         return output

--- a/apps/class-solid/public/python/bmi_class.py
+++ b/apps/class-solid/public/python/bmi_class.py
@@ -1,0 +1,70 @@
+class BmiClass:
+    def __init__(self):
+        self.config = {}
+        self.model = None
+        print("CLASS instantiated!")
+
+    def initialize(self, config: dict):
+        # from class_model import CLASS
+
+        self.config = config
+        self.model = CLASS(config)
+        print("CLASS initialized!")
+
+    def update(self):
+        self.model.update()
+
+    def get_component_name(self):
+        return "Chemistry Land-surface Atmosphere Soil Slab model"
+
+    def get_output_item_count(self):
+        return len(self.get_output_var_names())
+
+    def get_output_var_names(self):
+        return ["h", "theta", "dtheta", "q", "dq"]
+
+    def get_var_grid(self, name: str):
+        return 1
+
+    def get_var_type(self, name: str):
+        return "float"
+
+    def get_var_location(self, name: str):
+        return "node"
+
+    def get_current_time(self):
+        return self.model.t
+
+    def get_end_time(self):
+        return self.config["timeControl"]["runtime"]
+
+    def get_time_units(self):
+        return "s"
+
+    def get_time_step(self):
+        return self.config["timeControl"]["dt"]
+
+    def get_value(self, name: str):
+        if name in self.get_output_var_names():
+            return [getattr(self.model, name)]
+        raise ValueError(f"Variable {name} not found")
+
+    def get_grid_type(self):
+        return "scalar"
+
+    def run(self, freq=600, var_names=None):
+        if var_names is None:
+            var_names = self.get_output_var_names()
+
+        output = {"t": []}
+        for name in var_names:
+            output[name] = []
+
+        while self.model.t <= self.config["timeControl"]["runtime"]:
+            if self.model.t % freq == 0:
+                output["t"].append(self.model.t)
+                for name in var_names:
+                    output[name].append(getattr(self.model, name))
+            self.update()
+
+        return output

--- a/apps/class-solid/public/python/class_model.py
+++ b/apps/class-solid/public/python/class_model.py
@@ -1,0 +1,119 @@
+# Constants
+RHO = 1.2  # Density of air [kg m-3]
+CP = 1005.0  # Specific heat of dry air [J kg-1 K-1]
+
+
+class CLASS:
+    """
+    CLASS model definition.
+
+    Attributes:
+        _cfg: Object containing the model settings.
+        h: ABL height [m].
+        theta: Mixed-layer potential temperature [K].
+        dtheta: Temperature jump at h [K].
+        q: Mixed-layer specific humidity [kg kg-1].
+        dq: Specific humidity jump at h [kg kg-1].
+        t: Model time [s].
+    """
+
+    def __init__(self, config: dict):
+        """
+        Create object and initialize the model state.
+
+        Args:
+            config: Model settings as a dictionary.
+        """
+        self._cfg = config
+        self.h = config["initialState"]["h_0"]
+        self.theta = config["initialState"]["theta_0"]
+        self.dtheta = config["initialState"]["dtheta_0"]
+        self.q = config["initialState"]["q_0"]
+        self.dq = config["initialState"]["dq_0"]
+        self.t = 0
+
+    def update(self):
+        """Integrate mixed layer."""
+        dt = self._cfg["timeControl"]["dt"]
+        self.h += dt * self.htend
+        self.theta += dt * self.thetatend
+        self.dtheta += dt * self.dthetatend
+        self.q += dt * self.qtend
+        self.dq += dt * self.dqtend
+        self.t += dt
+
+    @property
+    def htend(self) -> float:
+        """Tendency of CLB [m s-1]."""
+        return self.we + self.ws
+
+    @property
+    def thetatend(self) -> float:
+        """Tendency of mixed-layer potential temperature [K s-1]."""
+        return (self._cfg["mixedLayer"]["wtheta"] - self.wthetae) / self.h + self._cfg[
+            "mixedLayer"
+        ]["advtheta"]
+
+    @property
+    def dthetatend(self) -> float:
+        """Tendency of potential temperature jump at h [K s-1]."""
+        w_th_ft = 0.0  # TODO: add free troposphere switch
+        return (
+            self._cfg["mixedLayer"]["gammatheta"] * self.we - self.thetatend + w_th_ft
+        )
+
+    @property
+    def qtend(self) -> float:
+        """Tendency of mixed-layer specific humidity [kg kg-1 s-1]."""
+        return (self._cfg["mixedLayer"]["wq"] - self.wqe) / self.h + self._cfg[
+            "mixedLayer"
+        ]["advq"]
+
+    @property
+    def dqtend(self) -> float:
+        """Tendency of specific humidity jump at h [kg kg-1 s-1]."""
+        w_q_ft = 0  # TODO: add free troposphere switch
+        return self._cfg["mixedLayer"]["gammaq"] * self.we - self.qtend + w_q_ft
+
+    @property
+    def we(self) -> float:
+        """Entrainment velocity [m s-1]."""
+        we = -self.wthetave / self.dthetav
+
+        # Don't allow boundary layer shrinking
+        return max(we, 0)
+
+    @property
+    def ws(self) -> float:
+        """Large-scale vertical velocity [m s-1]."""
+        return -self._cfg["mixedLayer"]["divU"] * self.h
+
+    @property
+    def wthetae(self) -> float:
+        """Entrainment kinematic heat flux [K m s-1]."""
+        return -self.we * self.dtheta
+
+    @property
+    def wqe(self) -> float:
+        """Entrainment moisture flux [kg kg-1 m s-1]."""
+        return -self.we * self.dq
+
+    @property
+    def wthetave(self) -> float:
+        """Entrainment kinematic virtual heat flux [K m s-1]."""
+        return -self._cfg["mixedLayer"]["beta"] * self.wthetav
+
+    @property
+    def dthetav(self) -> float:
+        """Virtual temperature jump at h [K]."""
+        return (self.theta + self.dtheta) * (
+            1.0 + 0.61 * (self.q + self.dq)
+        ) - self.theta * (1.0 + 0.61 * self.q)
+
+    @property
+    def wthetav(self) -> float:
+        """Surface kinematic virtual heat flux [K m s-1]."""
+        return (
+            self._cfg["mixedLayer"]["wtheta"]
+            + 0.61 * self.theta * self._cfg["mixedLayer"]["wq"]
+        )

--- a/apps/class-solid/src/lib/runner.ts
+++ b/apps/class-solid/src/lib/runner.ts
@@ -20,6 +20,7 @@ export async function runClass(config: PartialConfig, backend='pyodide'): Promis
     const model = backend === 'ts'
       ? await new AsyncBmiClass()
       : await new PyodideClass();
+    console.log(await model.get_component_name())
     await model.initialize(parsedConfig);
     const output = await model.run({
       var_names: new BmiClass().get_output_var_names(),

--- a/apps/class-solid/src/lib/runner.ts
+++ b/apps/class-solid/src/lib/runner.ts
@@ -9,10 +9,17 @@ const worker = new Worker(new URL("./worker.ts", import.meta.url), {
 });
 export const AsyncBmiClass = wrap<typeof BmiClass>(worker);
 
-export async function runClass(config: PartialConfig): Promise<ClassOutput> {
+const pyodideWorker = new Worker(new URL("./worker_pyodide.ts", import.meta.url), {
+  type: "module",
+});
+export const PyodideClass = wrap<typeof BmiClass>(pyodideWorker)
+
+export async function runClass(config: PartialConfig, backend='pyodide'): Promise<ClassOutput> {
   try {
     const parsedConfig: Config = parse(config);
-    const model = await new AsyncBmiClass();
+    const model = backend === 'ts'
+      ? await new AsyncBmiClass()
+      : await new PyodideClass();
     await model.initialize(parsedConfig);
     const output = await model.run({
       var_names: new BmiClass().get_output_var_names(),

--- a/apps/class-solid/src/lib/worker_pyodide.ts
+++ b/apps/class-solid/src/lib/worker_pyodide.ts
@@ -2,6 +2,7 @@ import { loadPyodide } from "https://cdn.jsdelivr.net/pyodide/v0.27.0/full/pyodi
 import type { BmiClass } from "@classmodel/class/bmi";
 import { expose } from "comlink";
 
+
 const bmiClassCode = `
 class SubClass:
     def __init__(self):
@@ -26,52 +27,86 @@ class BmiClass:
         return ["h", "theta", "dtheta", "q", "dq"]
 
     def run(self, var_names=["t"]):
-        output = {"t": []}
+        output = {"t": [10, 11, 12]}
         return output
 
+import json
 model = BmiClass()
 `
 
-function createBmiWrapper(pyodide): BmiClass {
+class BmiWrapper implements BmiClass {
+  private pyodide: any;
+  private bmiInstance: any;
 
-  pyodide.runPython(bmiClassCode);
-  const bmiInstance = pyodide.globals.get('model');
+  constructor() {
+    // Use the globally initialized pyodide
+    if (typeof pyodide === 'undefined') {
+      throw new Error("Pyodide is not loaded yet.");
+    }
 
+    this.pyodide = pyodide; // Access the global pyodide instance
 
-  // Return a Proxy that intercepts method calls and forwards them to the Python instance
-  return new Proxy({}, {
-      get: (target, prop, receiver) => {
-          // If the property is a function in the Python instance, forward the call
-          if (typeof prop === 'string' && prop in bmiInstance) {
-              const args = [...arguments].slice(2); // Collect arguments passed to the method
-              const methodCall = `${prop}(${args.map(arg => JSON.stringify(arg)).join(", ")})`;
-              // Forward the method call to the Python instance
-              console.log(methodCall)
-              return pyodide.runPython(`model.${methodCall}`);
-          }
-          // Return undefined for unknown properties
-          return undefined;
-      }
-  }) as BmiClass; // Cast the Proxy to BmiClass type
-}
+    // Load the Python BMI class code (this should only be done once)
+    this.pyodide.runPython(bmiClassCode);
+    console.log("Python BMI loaded");
 
-async function initializeWorker() {
-  try {
-      const pyodide = await loadPyodide();
-      console.log("Pyodide initialized!");
+    // Get the Python instance of the model
+    this.bmiInstance = this.pyodide.globals.get('model');
 
-      // Create the BMI wrapper
-      const model = createBmiWrapper(pyodide);
+    // Ensure that the model is initialized and has the expected methods
+    if (!this.bmiInstance) {
+      throw new Error("Failed to initialize Python BMI model.");
+    }
+  }
 
-      console.log(model.get_component_name());
-      model.initialize({ a: 10 });
-      console.log(model.get_value('random_var'));
-      const output = model.run({ var_names: ['t'] });
-      console.log(output);
-      console.log(typeof output);
-  } catch (error) {
-      console.error("Error initializing worker:", error);
+  get_component_name(): string {
+    return this.pyodide.runPython('model.get_component_name()');
+  }
+
+  initialize(cfg: object): void {
+    this.pyodide.runPython(`model.initialize(${JSON.stringify(cfg)})`);
+  }
+
+  get_value(varName: string): [number] {
+    return this.pyodide.runPython(`model.get_value(${JSON.stringify(varName)})`);
+  }
+
+  get_output_var_names(): string[] {
+    return this.pyodide.runPython('model.get_output_var_names()');
+  }
+
+  run<T extends string[]>({ freq, var_names }: { freq?: number; var_names?: T }): { t: number[] } & { [K in T[number]]: number[] } {
+    const varNames = JSON.stringify(var_names || ['t']);
+    const result = this.pyodide.runPython(`json.dumps(model.run(var_names=${varNames}))`)
+    const jsResult = JSON.parse((result))
+    console.log(result, jsResult)
+    return jsResult
   }
 }
 
-initializeWorker()
+// Global pyodide instance
+let pyodide: any;
+
+async function initializeWorker() {
+  try {
+    // Load Pyodide globally (this is done only once)
+    pyodide = await loadPyodide();
+    console.log("Pyodide initialized!");
+
+    // Create the BMI wrapper (no need to pass pyodide here)
+    const model = new BmiWrapper();
+    console.log(model.get_component_name());
+    model.initialize({ a: 10 });
+    console.log(model.get_value('random_var'));
+    const output = model.run({ var_names: ['t'] });
+    console.log(output);
+    console.log(typeof output);
+
+    expose(BmiWrapper); // Expose the BmiWrapper class to the main thread if needed
+
+  } catch (error) {
+    console.error("Error initializing worker:", error);
+  }
+}
+
+initializeWorker();

--- a/apps/class-solid/src/lib/worker_pyodide.ts
+++ b/apps/class-solid/src/lib/worker_pyodide.ts
@@ -1,0 +1,56 @@
+import { loadPyodide } from "https://cdn.jsdelivr.net/pyodide/v0.27.0/full/pyodide.mjs";
+import type { BmiClass } from "@classmodel/class/bmi";
+import { expose } from "comlink";
+
+// let pythonModel: BmiClass;
+
+
+function wrapPythonClass<T>(pyClass: any): { new (...args: any[]): T } {
+    return new Proxy(pyClass, {
+        construct(target, args) {
+        // Instantiate the Python class
+        const instance = target(...args);
+    
+        // Wrap the instance to ensure methods are callable
+        return new Proxy(instance, {
+            get(obj, prop) {
+            const value = obj[prop];
+            // If the property is a function, bind it to the instance and convert to JS
+            if (typeof value === "function") {
+                return (...methodArgs: any[]) => value(...methodArgs);
+            }
+            return value;
+            },
+        });
+        },
+    });
+    }
+
+async function initializeWorker() {
+    try {
+        const pyodide = await loadPyodide();
+        console.log("Pyodide initialized!");
+
+        const classModelCode = await fetch("/python/class_model.py").then((res) => res.text());
+        const bmiClassCode = await fetch("/python/bmi_class.py").then((res) => res.text());
+
+        await pyodide.runPython(classModelCode);
+        await pyodide.runPython(bmiClassCode);
+
+        // const pythonModel = pyodide.pyimport("BmiClass");
+        // const pythonModel = pyodide.globals.get("BmiClass") as unknown as PythonClass<BmiClass>;
+
+        const rawBmiClass = pyodide.globals.get("BmiClass");
+        const pythonModel = wrapPythonClass<BmiClass>(rawBmiClass);
+        const model = new pythonModel();
+
+    
+        console.log(model.get_component_name())
+        expose(pythonModel);
+    } catch (error) {
+        console.error("Worker initialization failed:", error);
+        throw error;
+    }
+}
+
+await initializeWorker();

--- a/apps/class-solid/src/lib/worker_pyodide.ts
+++ b/apps/class-solid/src/lib/worker_pyodide.ts
@@ -21,8 +21,12 @@ function wrapPythonClass<T>(pyClass: any): { new (...args: any[]): T } {
             if (value.__name__) {
               return wrapPythonClass(value);
             }
-            // Otherwise, it's a method, so just call it
-            return (...methodArgs: any[]) => value(...methodArgs);
+            // Otherwise, it's a method
+            return (...methodArgs: any[]) => {
+                // Call the method and handle the return value
+                const result = value(...methodArgs);
+                return wrapPythonReturnValue(result);
+              };
           }
           // If the property is an object, recursively wrap it
           if (value && typeof value === "object") {
@@ -40,7 +44,11 @@ function wrapPythonObject(pyObject: any): any {
     get(obj, prop) {
       const value = obj[prop];
       if (typeof value === "function") {
-        return (...methodArgs: any[]) => value(...methodArgs);
+        return (...methodArgs: any[]) => {
+            // Call the method and handle the return value
+            const result = value(...methodArgs);
+            return wrapPythonReturnValue(result);
+          };
       }
       if (value && typeof value === "function" && value.__name__) {
         return wrapPythonClass(value);
@@ -52,6 +60,35 @@ function wrapPythonObject(pyObject: any): any {
     },
   });
 }
+
+// Function to recursively convert Python objects to serializable JS objects
+function wrapPythonReturnValue(value: any): any {
+    if (value === null || value === undefined) {
+      return value; // Return null or undefined as is
+    }
+  
+    // If it's a simple type, return it directly
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      return value;
+    }
+  
+    // If it's a list, recursively wrap each element
+    if (Array.isArray(value)) {
+      return value.map(wrapPythonReturnValue);
+    }
+  
+    // If it's a dictionary-like object (e.g., Python dict), convert to plain JS object
+    if (typeof value === "object") {
+      const result: { [key: string]: any } = {};
+      for (const key in value) {
+        result[key] = wrapPythonReturnValue(value[key]);
+      }
+      return result;
+    }
+  
+    // If it's a function or other complex type, return as is (it will be handled by the wrapper)
+    return value;
+  }
 
 
 async function initializeWorker() {
@@ -68,13 +105,14 @@ async function initializeWorker() {
         const rawBmiClass = pyodide.globals.get("BmiClass");
         const pythonModel = wrapPythonClass<BmiClass>(rawBmiClass);
 
-        // Check that instatiation works without wrapping with comlink
+        // Check it works without wrapping with comlink
         const model = new pythonModel();
         console.log(model.get_component_name())
         model.initialize({a: 10});
-        console.log(model.get_value('random_var')); // Outputs: 42
+        console.log(model.get_value('random_var'));
         const output = model.run({var_names: ['t']});
         console.log(output)
+        console.log(typeof output)
     
         expose(pythonModel);
     } catch (error) {

--- a/apps/class-solid/src/lib/worker_pyodide.ts
+++ b/apps/class-solid/src/lib/worker_pyodide.ts
@@ -6,25 +6,53 @@ import { expose } from "comlink";
 
 
 function wrapPythonClass<T>(pyClass: any): { new (...args: any[]): T } {
-    return new Proxy(pyClass, {
-        construct(target, args) {
-        // Instantiate the Python class
-        const instance = target(...args);
-    
-        // Wrap the instance to ensure methods are callable
-        return new Proxy(instance, {
-            get(obj, prop) {
-            const value = obj[prop];
-            // If the property is a function, bind it to the instance and convert to JS
-            if (typeof value === "function") {
-                return (...methodArgs: any[]) => value(...methodArgs);
+  return new Proxy(pyClass, {
+    construct(target, args) {
+      // Instantiate the Python class
+      const instance = target(...args);
+
+      // Wrap the instance to ensure methods are callable
+      return new Proxy(instance, {
+        get(obj, prop) {
+          const value = obj[prop];
+          // If the property is a function, return a callable function
+          if (typeof value === "function") {
+            // If it's a class (has __name__), wrap it as a class
+            if (value.__name__) {
+              return wrapPythonClass(value);
             }
-            return value;
-            },
-        });
+            // Otherwise, it's a method, so just call it
+            return (...methodArgs: any[]) => value(...methodArgs);
+          }
+          // If the property is an object, recursively wrap it
+          if (value && typeof value === "object") {
+            return wrapPythonObject(value);
+          }
+          return value;
         },
-    });
-    }
+      });
+    },
+  });
+}
+
+function wrapPythonObject(pyObject: any): any {
+  return new Proxy(pyObject, {
+    get(obj, prop) {
+      const value = obj[prop];
+      if (typeof value === "function") {
+        return (...methodArgs: any[]) => value(...methodArgs);
+      }
+      if (value && typeof value === "function" && value.__name__) {
+        return wrapPythonClass(value);
+      }
+      if (value && typeof value === "object") {
+        return wrapPythonObject(value);
+      }
+      return value;
+    },
+  });
+}
+
 
 async function initializeWorker() {
     try {
@@ -34,18 +62,20 @@ async function initializeWorker() {
         const classModelCode = await fetch("/python/class_model.py").then((res) => res.text());
         const bmiClassCode = await fetch("/python/bmi_class.py").then((res) => res.text());
 
-        await pyodide.runPython(classModelCode);
+        // await pyodide.runPython(classModelCode);
         await pyodide.runPython(bmiClassCode);
-
-        // const pythonModel = pyodide.pyimport("BmiClass");
-        // const pythonModel = pyodide.globals.get("BmiClass") as unknown as PythonClass<BmiClass>;
 
         const rawBmiClass = pyodide.globals.get("BmiClass");
         const pythonModel = wrapPythonClass<BmiClass>(rawBmiClass);
-        const model = new pythonModel();
 
-    
+        // Check that instatiation works without wrapping with comlink
+        const model = new pythonModel();
         console.log(model.get_component_name())
+        model.initialize({a: 10});
+        console.log(model.get_value('random_var')); // Outputs: 42
+        const output = model.run({var_names: ['t']});
+        console.log(output)
+    
         expose(pythonModel);
     } catch (error) {
         console.error("Worker initialization failed:", error);


### PR DESCRIPTION
I've been playing around to try and run python code from the web application. As such, we could have an analogous implementation in Python and use the nice web application to manage and analyse our experiments.

There are multiply ways to achieve this:

- Pyodide: running a python interpreter in the browser. 
  Advantage: easy (?!), actual python code is being executed
  Disadvantage: long load time as it needs to initialize the full pyodide environment (though only inside the web worker)
- Transcrypt: transpiling the python code to js/ts
  Advantage: easy and fast, code can be optimized during build
  Disadvantage: for the purpose of "proof of concept", this is not much different than just writing js/ts directly
- Compiling python code directly to WASM, e.g. something like [py2wasm](https://wasmer.io/posts/py2wasm-a-python-to-wasm-compiler)
  Advantage: skips the overhead of loading pyodide and interpreting the python code; could scale to larger models and then be more efficient than js/ts
  Disadvantage: more challenging, would make more sense with more performance oriented libraries like Rust or C++

I decided to try the first option. Some notes

- Pyodide docs on running in webworker https://pyodide.org/en/stable/usage/webworker.html#
- However, we are using comlink; comlink doesn't like pyodide objects
- It would be much easier if we simply exposed the `run` method only, instead of the full BMI with all controls
- To still use BMI and comlink, we need a wrapper that takes care of properly forwarding function calls to python object and results back to js

I tried several approaches that go me almost there. Finally I managed to forward model output through comlink, but only through serialization on the python side and deserialization on the ts side. Then, comlink will do something similar again. How (un)desireable is that?

This PR still needs some work to reconcile the best elements of the different approaches I've tried and end up with a fully working version.