### PR TITLE
Add Rust implementation of CLASS

### DIFF
--- a/apps/class-solid/app.config.ts
+++ b/apps/class-solid/app.config.ts
@@ -1,8 +1,12 @@
 import { defineConfig } from "@solidjs/start/config";
+import wasm from "vite-plugin-wasm";
 
 console.log("process.env.BASE_PATH", process.env.BASE_PATH);
 
 export default defineConfig({
+  vite: {
+    plugins: [wasm()],
+  },
   ssr: false,
   server: {
     baseURL: process.env.BASE_PATH,

--- a/apps/class-solid/package.json
+++ b/apps/class-solid/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@classmodel/class": "workspace:*",
+    "@classmodel/class-rust": "workspace:*",
     "@kobalte/core": "^0.13.3",
     "@modular-forms/solid": "^0.23.0",
     "@solid-primitives/refs": "^1.0.8",
@@ -39,6 +40,7 @@
     "@types/d3": "^7.4.3",
     "@types/node": "^20.13.1",
     "serve": "^14.2.3",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vite-plugin-wasm": "^3.4.1"
   }
 }

--- a/apps/class-solid/src/routes/index.tsx
+++ b/apps/class-solid/src/routes/index.tsx
@@ -25,6 +25,11 @@ export default function Home() {
 
   onMount(onPageLoad);
 
+  const initModel = () => {
+    const model = new wasm.BmiClass();
+    alert(`Welcome to the ${model.get_component_name()}`)
+  }
+
   return (
     <main class="mx-auto p-4 text-center text-gray-700">
       <h2 class="my-8 text-4xl">
@@ -76,7 +81,7 @@ export default function Home() {
           <For each={analyses}>{(analysis) => AnalysisCard(analysis)}</For>
         </Flex>
       </Show>
-      <button onclick={wasm.greet}>Test WASM</button>
+      <button onclick={initModel}>Test WASM</button>
       <Toaster />
     </main>
   );

--- a/apps/class-solid/src/routes/index.tsx
+++ b/apps/class-solid/src/routes/index.tsx
@@ -16,6 +16,7 @@ import { Flex } from "~/components/ui/flex";
 import { Toaster } from "~/components/ui/toast";
 import { onPageLoad } from "~/lib/state";
 
+import * as wasm from "@classmodel/class-rust";
 import { addAnalysis, analysisNames, experiments } from "~/lib/store";
 import { analyses } from "~/lib/store";
 
@@ -49,7 +50,6 @@ export default function Home() {
           )}
         </For>
       </Flex>
-
       <h2 class="my-8 text-4xl">
         Analysis
         <Show when={experiments.length}>
@@ -76,6 +76,7 @@ export default function Home() {
           <For each={analyses}>{(analysis) => AnalysisCard(analysis)}</For>
         </Flex>
       </Show>
+      <button onclick={wasm.greet}>Test WASM</button>
       <Toaster />
     </main>
   );

--- a/packages/class-rust/.appveyor.yml
+++ b/packages/class-rust/.appveyor.yml
@@ -1,0 +1,11 @@
+install:
+  - appveyor-retry appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - if not defined RUSTFLAGS rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain nightly
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - rustc -V
+  - cargo -V
+
+build: false
+
+test_script:
+  - cargo test --locked

--- a/packages/class-rust/.github/dependabot.yml
+++ b/packages/class-rust/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "08:00"
+  open-pull-requests-limit: 10

--- a/packages/class-rust/.gitignore
+++ b/packages/class-rust/.gitignore
@@ -1,0 +1,6 @@
+/target
+**/*.rs.bk
+Cargo.lock
+bin/
+pkg/
+wasm-pack.log

--- a/packages/class-rust/.travis.yml
+++ b/packages/class-rust/.travis.yml
@@ -1,0 +1,69 @@
+language: rust
+sudo: false
+
+cache: cargo
+
+matrix:
+  include:
+
+  # Builds with wasm-pack.
+  - rust: beta
+    env: RUST_BACKTRACE=1
+    addons:
+      firefox: latest
+      chrome: stable
+    before_script:
+      - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
+      - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
+      - cargo install-update -a
+      - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -f
+    script:
+      - cargo generate --git . --name testing
+      # Having a broken Cargo.toml (in that it has curlies in fields) anywhere
+      # in any of our parent dirs is problematic.
+      - mv Cargo.toml Cargo.toml.tmpl
+      - cd testing
+      - wasm-pack build
+      - wasm-pack test --chrome --firefox --headless
+
+  # Builds on nightly.
+  - rust: nightly
+    env: RUST_BACKTRACE=1
+    before_script:
+      - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
+      - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
+      - cargo install-update -a
+      - rustup target add wasm32-unknown-unknown
+    script:
+      - cargo generate --git . --name testing
+      - mv Cargo.toml Cargo.toml.tmpl
+      - cd testing
+      - cargo check
+      - cargo check --target wasm32-unknown-unknown
+      - cargo check                                 --no-default-features
+      - cargo check --target wasm32-unknown-unknown --no-default-features
+      - cargo check                                 --no-default-features --features console_error_panic_hook
+      - cargo check --target wasm32-unknown-unknown --no-default-features --features console_error_panic_hook
+      - cargo check                                 --no-default-features --features "console_error_panic_hook wee_alloc"
+      - cargo check --target wasm32-unknown-unknown --no-default-features --features "console_error_panic_hook wee_alloc"
+
+  # Builds on beta.
+  - rust: beta
+    env: RUST_BACKTRACE=1
+    before_script:
+      - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
+      - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
+      - cargo install-update -a
+      - rustup target add wasm32-unknown-unknown
+    script:
+      - cargo generate --git . --name testing
+      - mv Cargo.toml Cargo.toml.tmpl
+      - cd testing
+      - cargo check
+      - cargo check --target wasm32-unknown-unknown
+      - cargo check                                 --no-default-features
+      - cargo check --target wasm32-unknown-unknown --no-default-features
+      - cargo check                                 --no-default-features --features console_error_panic_hook
+      - cargo check --target wasm32-unknown-unknown --no-default-features --features console_error_panic_hook
+      # Note: no enabling the `wee_alloc` feature here because it requires
+      # nightly for now.

--- a/packages/class-rust/Cargo.toml
+++ b/packages/class-rust/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "class-rust"
+version = "0.1.0"
+authors = ["Peter Kalverla <peter.kalverla@gmx.com>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["console_error_panic_hook"]
+
+[dependencies]
+wasm-bindgen = "0.2.84"
+
+# The `console_error_panic_hook` crate provides better debugging of panics by
+# logging them with `console.error`. This is great for development, but requires
+# all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
+# code size when deploying.
+console_error_panic_hook = { version = "0.1.7", optional = true }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.34"
+
+[profile.release]
+# Tell `rustc` to optimize for small code size.
+opt-level = "s"

--- a/packages/class-rust/Cargo.toml
+++ b/packages/class-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "class-rust"
-version = "0.1.0"
+version = "0.0.14"
 authors = ["Peter Kalverla <peter.kalverla@gmx.com>"]
 edition = "2018"
 

--- a/packages/class-rust/LICENSE_APACHE
+++ b/packages/class-rust/LICENSE_APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/class-rust/LICENSE_MIT
+++ b/packages/class-rust/LICENSE_MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2018 Peter Kalverla <peter.kalverla@gmx.com>
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/packages/class-rust/README.md
+++ b/packages/class-rust/README.md
@@ -1,0 +1,84 @@
+<div align="center">
+
+  <h1><code>wasm-pack-template</code></h1>
+
+  <strong>A template for kick starting a Rust and WebAssembly project using <a href="https://github.com/rustwasm/wasm-pack">wasm-pack</a>.</strong>
+
+  <p>
+    <a href="https://travis-ci.org/rustwasm/wasm-pack-template"><img src="https://img.shields.io/travis/rustwasm/wasm-pack-template.svg?style=flat-square" alt="Build Status" /></a>
+  </p>
+
+  <h3>
+    <a href="https://rustwasm.github.io/docs/wasm-pack/tutorials/npm-browser-packages/index.html">Tutorial</a>
+    <span> | </span>
+    <a href="https://discordapp.com/channels/442252698964721669/443151097398296587">Chat</a>
+  </h3>
+
+  <sub>Built with 🦀🕸 by <a href="https://rustwasm.github.io/">The Rust and WebAssembly Working Group</a></sub>
+</div>
+
+## About
+
+[**📚 Read this template tutorial! 📚**][template-docs]
+
+This template is designed for compiling Rust libraries into WebAssembly and
+publishing the resulting package to NPM.
+
+Be sure to check out [other `wasm-pack` tutorials online][tutorials] for other
+templates and usages of `wasm-pack`.
+
+[tutorials]: https://rustwasm.github.io/docs/wasm-pack/tutorials/index.html
+[template-docs]: https://rustwasm.github.io/docs/wasm-pack/tutorials/npm-browser-packages/index.html
+
+## 🚴 Usage
+
+### 🐑 Use `cargo generate` to Clone this Template
+
+[Learn more about `cargo generate` here.](https://github.com/ashleygwilliams/cargo-generate)
+
+```
+cargo generate --git https://github.com/rustwasm/wasm-pack-template.git --name my-project
+cd my-project
+```
+
+### 🛠️ Build with `wasm-pack build`
+
+```
+wasm-pack build
+```
+
+### 🔬 Test in Headless Browsers with `wasm-pack test`
+
+```
+wasm-pack test --headless --firefox
+```
+
+### 🎁 Publish to NPM with `wasm-pack publish`
+
+```
+wasm-pack publish
+```
+
+## 🔋 Batteries Included
+
+* [`wasm-bindgen`](https://github.com/rustwasm/wasm-bindgen) for communicating
+  between WebAssembly and JavaScript.
+* [`console_error_panic_hook`](https://github.com/rustwasm/console_error_panic_hook)
+  for logging panic messages to the developer console.
+* `LICENSE-APACHE` and `LICENSE-MIT`: most Rust projects are licensed this way, so these are included for you
+
+## License
+
+Licensed under either of
+
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you, as defined in the Apache-2.0
+license, shall be dual licensed as above, without any additional terms or
+conditions.

--- a/packages/class-rust/src/lib.rs
+++ b/packages/class-rust/src/lib.rs
@@ -1,0 +1,13 @@
+mod utils;
+
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    fn alert(s: &str);
+}
+
+#[wasm_bindgen]
+pub fn greet() {
+    alert("Hello, class-rust!");
+}

--- a/packages/class-rust/src/lib.rs
+++ b/packages/class-rust/src/lib.rs
@@ -1,13 +1,203 @@
-mod utils;
-
 use wasm_bindgen::prelude::*;
 
+
+mod utils;
+use utils::GenericOption;
+
+// Configuration
+
 #[wasm_bindgen]
-extern "C" {
-    fn alert(s: &str);
+#[derive(Copy,Clone)]
+pub struct Config {
+    pub time_control: TimeControl,
+    pub initial_state: InitialState,
+    pub mixed_layer: MixedLayer,
 }
 
 #[wasm_bindgen]
-pub fn greet() {
-    alert("Hello, class-rust!");
+#[derive(Copy,Clone)]
+pub struct TimeControl {
+    pub runtime: f64,
+    pub dt: f64,
 }
+
+#[wasm_bindgen]
+#[derive(Copy,Clone)]
+pub struct InitialState {
+    pub h_0: f64,
+    pub theta_0: f64,
+    pub dtheta_0: f64,
+    pub q_0: f64,
+    pub dq_0: f64,
+}
+
+#[wasm_bindgen]
+#[derive(Copy,Clone)]
+pub struct MixedLayer {
+    pub wtheta: f64,
+    pub wq: f64,
+    pub advtheta: f64,
+    pub advq: f64,
+    pub gammatheta: f64,
+    pub gammaq: f64,
+    pub beta: f64,
+    pub div_u: f64,
+}
+
+#[wasm_bindgen]
+#[derive(Copy,Clone)]
+pub struct CLASS {
+    h: f64,
+    theta: f64,
+    dtheta: f64,
+    q: f64,
+    dq: f64,
+    t: f64,
+    cfg: Config,
+}
+
+// Core model
+
+#[wasm_bindgen]
+impl CLASS {
+    #[wasm_bindgen(constructor)]
+    pub fn new(cfg: Config) -> CLASS {
+        CLASS {
+            h: cfg.initial_state.h_0,
+            theta: cfg.initial_state.theta_0,
+            dtheta: cfg.initial_state.dtheta_0,
+            q: cfg.initial_state.q_0,
+            dq: cfg.initial_state.dq_0,
+            t: 0.0,
+            cfg,
+        }
+    }
+
+    pub fn update(&mut self) {
+        let dt = self.cfg.time_control.dt;
+        self.h += dt * self.htend();
+        self.theta += dt * self.thetatend();
+        self.dtheta += dt * self.dthetatend();
+        self.q += dt * self.qtend();
+        self.dq += dt * self.dqtend();
+        self.t += dt;
+    }
+
+    fn htend(&self) -> f64 {
+        self.we() + self.ws()
+    }
+
+    fn thetatend(&self) -> f64 {
+        (self.cfg.mixed_layer.wtheta - self.wthetae()) / self.h + self.cfg.mixed_layer.advtheta
+    }
+
+    fn dthetatend(&self) -> f64 {
+        let w_th_ft = 0.0; // Placeholder for free troposphere switch
+        self.cfg.mixed_layer.gammatheta * self.we() - self.thetatend() + w_th_ft
+    }
+
+    fn qtend(&self) -> f64 {
+        (self.cfg.mixed_layer.wq - self.wqe()) / self.h + self.cfg.mixed_layer.advq
+    }
+
+    fn dqtend(&self) -> f64 {
+        let w_q_ft = 0.0; // Placeholder for free troposphere switch
+        self.cfg.mixed_layer.gammaq * self.we() - self.qtend() + w_q_ft
+    }
+
+    fn we(&self) -> f64 {
+        let mut we = -self.wthetave() / self.dthetav();
+        if we < 0.0 {
+            we = 0.0;
+        }
+        we
+    }
+
+    fn ws(&self) -> f64 {
+        -self.cfg.mixed_layer.div_u * self.h
+    }
+
+    fn wthetae(&self) -> f64 {
+        -self.we() * self.dtheta
+    }
+
+    fn wqe(&self) -> f64 {
+        -self.we() * self.dq
+    }
+
+    fn wthetave(&self) -> f64 {
+        -self.cfg.mixed_layer.beta * self.wthetav()
+    }
+
+    fn dthetav(&self) -> f64 {
+        (self.theta + self.dtheta) * (1.0 + 0.61 * (self.q + self.dq)) -
+        self.theta * (1.0 + 0.61 * self.q)
+    }
+
+    fn wthetav(&self) -> f64 {
+        self.cfg.mixed_layer.wtheta + 0.61 * self.theta * self.cfg.mixed_layer.wq
+    }
+}
+
+// Basic model interface (light)
+
+#[wasm_bindgen]
+pub struct BmiClass {
+    model: GenericOption<CLASS>,
+    config: GenericOption<Config>,
+}
+
+#[wasm_bindgen]
+impl BmiClass {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> BmiClass {
+        BmiClass {
+            // GenericOption allows us to use Option<T> as if it was T, without having to as_ref() or as_mut() everywhere
+            model: GenericOption::new("Model not available - call initialize first".to_string()),
+            config: GenericOption::new("Config not available - call initialize first".to_string()),
+        }
+    }
+
+    pub fn initialize(&mut self, config: Config) {
+        self.model.set(CLASS::new(config.clone()));
+        self.config.set(config);
+    }
+
+    pub fn update(&mut self) {
+        self.model.update();
+    }
+
+    pub fn get_component_name(&self) -> String {
+        "Chemistry Land-surface Atmosphere Soil Slab model".to_string()
+    }
+
+    pub fn get_current_time(&self) -> f64 {
+        self.model.t
+    }
+
+    pub fn get_end_time(&self) -> f64 {
+        self.config.time_control.runtime
+    }
+
+    pub fn get_time_step(&self) -> f64 {
+        self.config.time_control.dt
+    }
+
+    pub fn get_value(&self, variable: &str) -> f64 {
+        // TODO: could use macros to reduce repetition and simulate dynamic access
+        match variable {
+            "t" => self.model.t,
+            "h" => self.model.h,
+            "theta" => self.model.theta,
+            "dtheta" => self.model.dtheta,
+            "q" => self.model.q,
+            "dq" => self.model.dq,
+            _ => panic!("Unknown variable: {}", variable),
+        }
+    }
+}
+
+// Note: run method should be implemented by client.
+// Not so great alternatives:
+//   - store all model state in default struct and expose that (no `variables` argument); but length of output is not known a priory
+//   - store requested variables in hashmap and somehow pass that onto js (serde?)

--- a/packages/class-rust/src/utils.rs
+++ b/packages/class-rust/src/utils.rs
@@ -1,0 +1,10 @@
+pub fn set_panic_hook() {
+    // When the `console_error_panic_hook` feature is enabled, we can call the
+    // `set_panic_hook` function at least once during initialization, and then
+    // we will get better error messages if our code ever panics.
+    //
+    // For more details see
+    // https://github.com/rustwasm/console_error_panic_hook#readme
+    #[cfg(feature = "console_error_panic_hook")]
+    console_error_panic_hook::set_once();
+}

--- a/packages/class-rust/src/utils.rs
+++ b/packages/class-rust/src/utils.rs
@@ -1,3 +1,6 @@
+use std::ops::Deref;
+use std::ops::DerefMut;
+
 pub fn set_panic_hook() {
     // When the `console_error_panic_hook` feature is enabled, we can call the
     // `set_panic_hook` function at least once during initialization, and then
@@ -8,3 +11,48 @@ pub fn set_panic_hook() {
     #[cfg(feature = "console_error_panic_hook")]
     console_error_panic_hook::set_once();
 }
+
+
+// Generic wrapper for Option<T> with a custom panic message
+pub struct GenericOption<T> {
+    value: Option<T>,
+    panic_message: String, 
+}
+
+impl<T> GenericOption<T> {
+    pub fn new(panic_message: String) -> Self {
+        GenericOption {
+            value: None,
+            panic_message,
+        }
+    }
+
+    pub fn value_or_panic(&self) -> &T {
+        self.value.as_ref().expect(&self.panic_message)
+    }
+
+    pub fn value_or_panic_mut(&mut self) -> &mut T {
+        self.value.as_mut().expect(&self.panic_message)
+    }
+
+    pub fn set(&mut self, new_value: T) {
+        self.value.replace(new_value);
+    }
+}
+
+// Implement Deref so GenericOption behaves like T
+impl<T> Deref for GenericOption<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.value_or_panic()
+    }
+}
+
+// Implement DerefMut so GenericOption behaves like T mutably
+impl<T> DerefMut for GenericOption<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.value_or_panic_mut()
+    }
+}
+

--- a/packages/class-rust/tests/web.rs
+++ b/packages/class-rust/tests/web.rs
@@ -1,0 +1,13 @@
+//! Test suite for the Web and headless browsers.
+
+#![cfg(target_arch = "wasm32")]
+
+extern crate wasm_bindgen_test;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn pass() {
+    assert_eq!(1 + 1, 2);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@classmodel/class':
         specifier: workspace:*
         version: link:../../packages/class
+      '@classmodel/class-rust':
+        specifier: workspace:*
+        version: link:../../packages/class-rust/pkg
       '@kobalte/core':
         specifier: ^0.13.3
         version: 0.13.3(solid-js@1.8.18)
@@ -99,6 +102,9 @@ importers:
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
+      vite-plugin-wasm:
+        specifier: ^3.4.1
+        version: 3.4.1(vite@5.4.6(@types/node@20.14.10)(sass@1.77.6)(terser@5.31.2))
 
   packages/class:
     dependencies:
@@ -130,6 +136,8 @@ importers:
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
+
+  packages/class-rust/pkg: {}
 
 packages:
 
@@ -3511,6 +3519,11 @@ packages:
     peerDependenciesMeta:
       '@testing-library/jest-dom':
         optional: true
+
+  vite-plugin-wasm@3.4.1:
+    resolution: {integrity: sha512-ja3nSo2UCkVeitltJGkS3pfQHAanHv/DqGatdI39ja6McgABlpsZ5hVgl6wuR8Qx5etY3T5qgDQhOWzc5RReZA==}
+    peerDependencies:
+      vite: ^2 || ^3 || ^4 || ^5 || ^6
 
   vite@5.4.6:
     resolution: {integrity: sha512-IeL5f8OO5nylsgzd9tq4qD2QqI0k2CQLGrWD0rCN0EQJZpBK5vJAx0I+GDkMOXxQX/OfFHMuLIx6ddAxGX/k+Q==}
@@ -7165,6 +7178,10 @@ snapshots:
       vitefu: 0.2.5(vite@5.4.6(@types/node@20.14.10)(sass@1.77.6)(terser@5.31.2))
     transitivePeerDependencies:
       - supports-color
+
+  vite-plugin-wasm@3.4.1(vite@5.4.6(@types/node@20.14.10)(sass@1.77.6)(terser@5.31.2)):
+    dependencies:
+      vite: 5.4.6(@types/node@20.14.10)(sass@1.77.6)(terser@5.31.2)
 
   vite@5.4.6(@types/node@20.14.10)(sass@1.77.6)(terser@5.31.2):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "apps/*"
   - "packages/*"
+  - "packages/class-rust/pkg"


### PR DESCRIPTION
I played around with the [Rust+WebAssembly book/tutorial](https://rustwasm.github.io/book/game-of-life/hello-world.html).

On build, a nice js/wasm package is created that can be used in the web app. It includes a `class-rust.d.ts` type definition file which should hopefully make for a smooth integration with the ts code.

To do:

- [ ] Use in runner / web worker
- [ ] Check/complete Bmi(Light)
- [ ] Change license
- [ ] Build/watch from turbo (build command: `wasm-pack build --scope classmodel`)
- [ ] Document install instructions (see https://rustwasm.github.io/book/game-of-life/setup.html except npm part)

Notes:
- It probably makes sense to implement the `run` method in the client outside of Bmi(Light), as it returns a complex type that's hard to transfer between rust/ts. The same was seen in #100 
- Would be useful to add update_until so you can update until next output time, that will reduce calls back and forth
- Rust code is quite prone to duplication, e.g. each variable that must be availabe via get value is defined four times (on the type, in the constructor, in the getter, and possibly also in an enum for `get_output_var_names`). This could be optimized by using macros.
- Local dev server doesn't appreciate being put in bg job with this branch
- I was annoyed with the Option type in rust (having to always use `.as_ref()` or `as_mut` and `expect(...)`, which made the code ugly and unreadable), so I spent some effort writing a wrapper around it with a default panic message. This is also due to the annoying fact that in BMI, the Model and Config are only set on initialize() call rather than in constructor. 