### PR TITLE
Update tickformat on plots

### DIFF
--- a/apps/class-solid/src/components/plots/Axes.tsx
+++ b/apps/class-solid/src/components/plots/Axes.tsx
@@ -19,7 +19,7 @@ export const AxisBottom = (props: AxisProps) => {
     props.type && updateChart("scalePropsX", { type: props.type });
   });
 
-  const format = () => (props.tickFormat ? props.tickFormat : d3.format(".3g"));
+  const format = () => (props.tickFormat ? props.tickFormat : d3.format(".4"));
   const ticks = () => props.tickValues || generateTicks(chart.scaleX.domain());
   return (
     <g transform={`translate(0,${chart.innerHeight - 0.5})`}>
@@ -49,7 +49,7 @@ export const AxisLeft = (props: AxisProps) => {
   });
 
   const ticks = () => props.tickValues || generateTicks(chart.scaleY.domain());
-  const format = () => (props.tickFormat ? props.tickFormat : d3.format(".0f"));
+  const format = () => (props.tickFormat ? props.tickFormat : d3.format(".4"));
   return (
     <g transform="translate(-0.5,0)">
       <line


### PR DESCRIPTION
closes #99 

Now uses d3 `~g` aka "None" format by default with 4 significant digits. That is:

This means numbers are rounded to 4 significant digits. Insignificant trailing zeros are removed. So we have:

1000 m
287 K
0.01 kg/kg
...

e.g.

![image](https://github.com/user-attachments/assets/55ac2304-bc69-471a-8500-e4476fc8807e)
