### PR TITLE
Set default start time of profile plots to 0

### DIFF
--- a/apps/class-solid/src/lib/store.ts
+++ b/apps/class-solid/src/lib/store.ts
@@ -287,7 +287,7 @@ export function addAnalysis(name: string) {
         type: "profiles",
         name: "Vertical profiles",
         variable: "Potential temperature [K]",
-        time: Number.POSITIVE_INFINITY,
+        time: 0,
       } as ProfilesAnalysis;
       break;
     case "Thermodynamic diagram":
@@ -296,7 +296,7 @@ export function addAnalysis(name: string) {
         description: "",
         type: "skewT",
         name: "Thermodynamic diagram",
-        time: Number.POSITIVE_INFINITY,
+        time: 0,
       } as SkewTAnalysis;
       break;
     default:


### PR DESCRIPTION
Plots with time sliders now start at 0.