### PR TITLE
Use solid router A component

### DIFF
--- a/apps/class-solid/src/components/Nav.tsx
+++ b/apps/class-solid/src/components/Nav.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from "@solidjs/router";
+import { A, useLocation } from "@solidjs/router";
 import { saveToLocalStorage } from "~/lib/state";
 import { ShareButton } from "./ShareButton";
 import { MdiContentSave } from "./icons";
@@ -13,11 +13,11 @@ export default function Nav() {
     <nav class="bg-sky-800">
       <ul class="container flex items-center gap-4 p-3 text-gray-200">
         <li class={`border-b-2 ${active("/")}l`}>
-          <a href="/">CLASS</a>
+          <A href="/">CLASS</A>
         </li>
         <li class=" w-full" />
         <li class={`border-b-2 ${active("/about")}`}>
-          <a href="/about">About</a>
+          <A href="/about">About</A>
         </li>
         <li>
           <button


### PR DESCRIPTION
The A component is aware of the baseUrl while a tag is not.

This also fixes link to about page when BASE_PATH env var is set during build.

Fixes #122

Tested with

```shell
BASE_PATH=/foobar pnpm build
apps/class-solid/.output
cp -r public foobar
python3 -m http.server
```
Goto http://0.0.0.0:8000/foobar and navigate to about page and back.
(note http://0.0.0.0:8000/foobar/about does not work with python server, but does on GH pages)
