### PR TITLE
Convert all structuredclones to json stringify parse

### DIFF
--- a/apps/class-solid/src/components/Experiment.tsx
+++ b/apps/class-solid/src/components/Experiment.tsx
@@ -17,6 +17,7 @@ import {
   duplicateExperiment,
   modifyExperiment,
 } from "~/lib/store";
+import { deepCopy } from "~/lib/utils";
 import { ExperimentConfigForm } from "./ExperimentConfigForm";
 import { ObservationsList } from "./ObservationsList";
 import { PermutationsList } from "./PermutationsList";
@@ -63,7 +64,7 @@ export function AddExperimentDialog(props: {
     return {
       preset: "Default",
       reference: {
-        ...structuredClone(defaultPreset.config),
+        ...deepCopy(defaultPreset.config),
         name: `My experiment ${props.nextIndex}`,
       },
       permutations: [],

--- a/apps/class-solid/src/components/PermutationsList.tsx
+++ b/apps/class-solid/src/components/PermutationsList.tsx
@@ -14,6 +14,7 @@ import {
   setPermutationConfigInExperiment,
   swapPermutationAndReferenceConfiguration,
 } from "~/lib/store";
+import { deepCopy } from "~/lib/utils";
 import {
   MdiCakeVariantOutline,
   MdiCog,
@@ -69,7 +70,7 @@ function AddPermutationButton(props: {
   const [open, setOpen] = createSignal(false);
 
   const initialPermutationConfig = createMemo(() => {
-    const config = structuredClone(unwrap(props.experiment.config.reference));
+    const config = deepCopy(unwrap(props.experiment.config.reference));
     config.name = `${props.experiment.config.permutations.length + 1}`;
     config.description = "";
     return config;

--- a/apps/class-solid/src/lib/store.ts
+++ b/apps/class-solid/src/lib/store.ts
@@ -13,6 +13,7 @@ import { parseExperimentConfig } from "./experiment_config";
 import type { ExperimentConfig } from "./experiment_config";
 import { findPresetByName } from "./presets";
 import { runClass } from "./runner";
+import { deepCopy } from "./utils";
 
 interface ExperimentOutput {
   reference?: ClassOutput;
@@ -112,7 +113,7 @@ export async function uploadExperiment(rawData: unknown) {
 }
 
 export function duplicateExperiment(id: number) {
-  const config = structuredClone(findExperiment(id).config);
+  const config = deepCopy(findExperiment(id).config);
   config.reference.name = `Copy of ${config.reference.name}`;
   const newExperiment: Experiment = {
     config: config,
@@ -191,7 +192,7 @@ export function promotePermutationToExperiment(
   const exp = findExperiment(experimentIndex);
   const perm = exp.config.permutations[permutationIndex];
 
-  const newConfig = structuredClone(perm);
+  const newConfig = deepCopy(perm);
   addExperiment(newConfig);
   // TODO should permutation be removed from original experiment?
 }
@@ -201,7 +202,7 @@ export function duplicatePermutation(
   permutationIndex: number,
 ) {
   const exp = findExperiment(experimentIndex);
-  const perm = structuredClone(exp.config.permutations[permutationIndex]);
+  const perm = deepCopy(exp.config.permutations[permutationIndex]);
   perm.name = `Copy of ${perm.name}`;
   setPermutationConfigInExperiment(experimentIndex, -1, perm);
   runExperiment(experimentIndex);
@@ -212,9 +213,9 @@ export function swapPermutationAndReferenceConfiguration(
   permutationIndex: number,
 ) {
   const exp = findExperiment(experimentIndex);
-  const refConfig = structuredClone(exp.config.reference);
+  const refConfig = deepCopy(exp.config.reference);
   const perm = exp.config.permutations[permutationIndex];
-  const permConfig = structuredClone(perm);
+  const permConfig = deepCopy(perm);
 
   setExperiments(experimentIndex, "config", "reference", permConfig);
   setExperiments(

--- a/apps/class-solid/src/lib/utils.ts
+++ b/apps/class-solid/src/lib/utils.ts
@@ -5,3 +5,24 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Creates a deep copy of the given object by serializing it to JSON and then
+ * deserializing it back.
+ *
+ * @typeParam T - The type of the object to be copied.
+ * @param obj - The object to create a deep copy of.
+ * @returns A new object that is a deep copy of the input object.
+ *
+ * @remarks
+ * This function uses `JSON.stringify` and `JSON.parse` to perform the deep
+ * copy. It works well for plain objects and arrays but may not handle objects
+ * with methods, circular references, or special types like `Date`, `Map`,
+ * `Set`, etc.
+ *
+ * Unlike structuredClone, this method does not preserve references. This is to
+ * avoid uncaught reference errors.
+ */
+export function deepCopy<T>(obj: T){
+  return JSON.parse(JSON.stringify(obj)) as T
+}

--- a/packages/class/src/config_utils.ts
+++ b/packages/class/src/config_utils.ts
@@ -64,7 +64,7 @@ export function pruneConfig(
   reference: Config,
   preset?: Config,
 ): PartialConfig {
-  let config = structuredClone(permutation);
+  let config = JSON.parse(JSON.stringify(permutation)) as Config;
   let config2 = reference;
   if (preset) {
     config = pruneConfig(permutation, reference) as Config;

--- a/packages/form/src/Form.tsx
+++ b/packages/form/src/Form.tsx
@@ -50,6 +50,7 @@ import {
   type Item,
   type SchemaOfProperty,
   buildValidate,
+  deepCopy,
   isBase,
   isBooleanChoices,
   isGroup,
@@ -123,7 +124,7 @@ function createFormStore(
     schema: JSONSchemaType<GenericConfig>;
   }>({
     // Copy props.values as initial form values
-    values: structuredClone(unwrap(initialValues)),
+    values: deepCopy(unwrap(initialValues)),
     errors: [],
     schema: schema(),
   });
@@ -138,7 +139,7 @@ function createFormStore(
       setStore("errors", errors);
     },
     reset: () => {
-      setStore("values", structuredClone(initialValues));
+      setStore("values", deepCopy(initialValues));
       setStore("errors", []);
     },
     get errors() {

--- a/packages/form/src/Form.tsx
+++ b/packages/form/src/Form.tsx
@@ -139,7 +139,7 @@ function createFormStore(
       setStore("errors", errors);
     },
     reset: () => {
-      setStore("values", deepCopy(initialValues));
+      setStore("values", deepCopy(unwrap(initialValues)));
       setStore("errors", []);
     },
     get errors() {

--- a/packages/form/src/utils.test.ts
+++ b/packages/form/src/utils.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import type { JSONSchemaType } from "ajv/dist/2020";
-import { type Item, overwriteDefaultsInJsonSchema, schema2tree } from "./utils";
+import { type Item, deepCopy, overwriteDefaultsInJsonSchema, schema2tree } from "./utils";
 
 type Config = {
   s1: string;
@@ -274,11 +274,11 @@ describe("schema2tree", () => {
 
 describe("overwriteDefaultsInJsonSchema", () => {
   test("given new default for s1 should return schema with given default", () => {
-    const schema = structuredClone(jsonSchemaOfConfig);
+    const schema = deepCopy(jsonSchemaOfConfig);
 
     const result = overwriteDefaultsInJsonSchema(schema, defaults);
 
-    const expected = structuredClone(jsonSchemaOfConfig);
+    const expected = deepCopy(jsonSchemaOfConfig);
     expected.properties.s1.default = "string2";
 
     assert.deepEqual(result, expected);

--- a/packages/form/src/utils.ts
+++ b/packages/form/src/utils.ts
@@ -320,3 +320,24 @@ export function schema2tree<C>(schema: JSONSchemaType<C>): Item[] {
   }
   return tree;
 }
+
+/**
+ * Creates a deep copy of the given object by serializing it to JSON and then
+ * deserializing it back.
+ *
+ * @typeParam T - The type of the object to be copied.
+ * @param obj - The object to create a deep copy of.
+ * @returns A new object that is a deep copy of the input object.
+ *
+ * @remarks
+ * This function uses `JSON.stringify` and `JSON.parse` to perform the deep
+ * copy. It works well for plain objects and arrays but may not handle objects
+ * with methods, circular references, or special types like `Date`, `Map`,
+ * `Set`, etc.
+ *
+ * Unlike structuredClone, this method does not preserve references. This is to
+ * avoid uncaught reference errors.
+ */
+export function deepCopy<T>(obj: T){
+  return JSON.parse(JSON.stringify(obj)) as T
+}


### PR DESCRIPTION
Attempting to fix #131 but so far unsuccessful. On production build I can now edit the settings once, but after that it fails with `InternalError: too much recursion`